### PR TITLE
Fix LaTeX warning (#39)

### DIFF
--- a/chapters/circuit-compilers-moonmath.tex
+++ b/chapters/circuit-compilers-moonmath.tex
@@ -716,7 +716,8 @@ We then proceed inductively choosing circuits for the outer most operators, whic
 \end{center}
 
 \end{example}
-\end{comment}\sme{Is the comment group hidden on purpose?}
+\end{comment}
+\sme{Is the comment group hidden on purpose?}
 
 \subsubsection{The boolean Type} 
 % implementations can be found here: https://github.com/filecoin-project/zexe/tree/master/snark-gadgets/src/bits


### PR DESCRIPTION
This should get rid of the following Warning:
> Characters dropped after `\end{comment}' on input line ...