### PR TITLE
Fix typo in elliptic-curves-moonmath.tex

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -2074,7 +2074,7 @@ x=3 & (t(x),p(x)) & (4,\frac{37}{3})\\
 x=4 & (t(x),p(x)) & (5,43)\\
 \end{array}
 $$
-Since $p(1)=1$ is not a prime number, the first $x$ that gives a proper curve is $x=2$. However, such a curve would be defined over a base field of characteristic $3$, and we would rather like to avoid that, since we only defined elliptic curves over fields of characteristics larger then $3$ in this book. We therefore find $x=4$, which defines a curve over the prime field of characteristic $43$ that has a trace of Frobenius $t=5$. 
+Since $p(1)=1$ is not a prime number, the first $x$ that gives a proper curve is $x=2$. However, such a curve would be defined over a base field of characteristic $3$, and we would rather like to avoid that, since we only defined elliptic curves over fields of characteristics larger than $3$ in this book. We therefore find $x=4$, which defines a curve over the prime field of characteristic $43$ that has a trace of Frobenius $t=5$. 
 
 Since the prime field $\F_{43}$ has $43$ elements and $43$'s binary representation is $43_2= 101011$, which consists of $6$ digits, the name of our pen-and-paper curve should be $BLS6\_6$, since its is common to name a BLS curve by its embedding degree and the bit-length of the modulus in the base field. We call $BLS6\_6$ the \term{moon-math-curve}.
 


### PR DESCRIPTION
Changed "larger then" into "larger than". Great book by the way