### PR TITLE
Update footnote in R1CS representation

### DIFF
--- a/chapters/statements-moonmath.tex
+++ b/chapters/statements-moonmath.tex
@@ -298,7 +298,8 @@ In this section, we will have a closer look at a particular type of quadratic eq
 \subsubsection{R1CS representation} To understand what \term{Rank-1 (quadratic) Constraint Systems} )(R1CS) are in detail, let $\F$ be a field, $n$, $m$ and $k\in\N$ three numbers and $a_j^i$, $b_j^i$ and $c_j^i\in\F$ constants from $\F$ for every index $0\leq j \leq n+m$ and $1\leq i \leq k$. Then a \concept{rank-1 constraint system} is defined as the following set of $k$ many equations:\tbdsm{font size too small} 
 
 \begin{definition}[\deftitle{Rank-1 (quadratic) Constraint System}]\label{R1CS}
-\begin{align*}
+\begin{equation}\label{eq:R1CS}
+\begin{split}
 \scriptstyle\left(a^1_0 + \sum_{j=1}^n a^1_j \cdot I_j + \sum_{j=1}^m a^1_{n+j} \cdot W_j  \right) \cdot 
 \left(b^1_0 + \sum_{j=1}^n b^1_j \cdot I_j + \sum_{j=1}^m b^1_{n+j} \cdot W_j  \right) &=\, 
 \scriptstyle c^1_0 + \sum_{j=1}^n c^1_j \cdot I_j + \sum_{j=1}^m c^1_{n+j} \cdot W_j\\
@@ -306,7 +307,8 @@ In this section, we will have a closer look at a particular type of quadratic eq
 \scriptstyle\left(a^k_0 + \sum_{j=1}^n a^k_j \cdot I_j + \sum_{j=1}^m a^k_{n+j} \cdot W_j  \right) \cdot 
 \left(b^k_0 + \sum_{j=1}^n b^k_j \cdot I_j + \sum_{j=1}^m b^k_{n+j} \cdot W_j  \right) &=\, 
 \scriptstyle c^k_0 + \sum_{j=1}^n c^k_j \cdot I_j + \sum_{j=1}^m c^k_{n+j} \cdot W_j       
-\end{align*}
+\end{split}
+\end{equation}
 \end{definition}
 
 In a \concept{rank-1 constraint system}, the parameter $k$ is called the \term{number of constraints}, and each equation is called a \term{constraint}. If a pair of strings of field elements $(<I_1,\ldots, I_n>; <W_1,\ldots,W_m>)$  satisfies theses equations, $<I_1,\ldots, I_n>$ is called an \term{instance} and $<W_1,\ldots,W_m>$ is called a \term{witness} of the system.%
@@ -314,7 +316,7 @@ In a \concept{rank-1 constraint system}, the parameter $k$ is called the \term{n
 $$
 Ax \odot Bx = Cx
 $$
-However,  since we did not introduce vector spaces and matrix calculus in the book, we use XXX as the defining equation for \concept{rank-1 constraint systems}. We only highlighted the matrix notation because it is sometimes used in the literature.}\sme{add reference to footnote}
+However,  since we did not introduce vector spaces and matrix calculus in the book, we use \ref{eq:R1CS} as the defining equation for \concept{rank-1 constraint systems}. We only highlighted the matrix notation because it is sometimes used in the literature.}
 
 It can be shown that every bounded computation is expressible as a \concept{rank-1 constraint system}. R1CS is therefore a universal model for bounded computations. We will derive some insights into common approaches of how to compile bounded computation into \concept{rank-1 constraint systems} in \chaptname{} \ref{chap:circuit-compilers}. 
 


### PR DESCRIPTION
Changed the align* equation to a split one to refer to it in the footnote.
I didn't find conflicting label, so I called the equation 'eq:R1CS'