### PR TITLE
Fix typo in isomorphic curves exercise: E_{7,5} instead of E_{5,12}

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -209,7 +209,7 @@ Let $\F$ be a finite field, let $(a,b)$ and $(a',b')$ be two pairs of parameters
 \end{exercise}
 
 \begin{exercise}
-\label{ex:isomorphic_TJJ13} Consider the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13} and the elliptic curve $E_{5,12}(\F_{13})$ defined as follows:
+\label{ex:isomorphic_TJJ13} Consider the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13} and the elliptic curve $E_{7,5}(\F_{13})$ defined as follows:
 \begin{equation}
 E_{7,5}(\F_{13}) = \{ (x,y)\in \F_{13}\times \F_{13}\;|\; y^2 = x^3 + 7x +5\}
 \end{equation}


### PR DESCRIPTION
![Selection_025](https://github.com/LeastAuthority/moonmath-manual/assets/15320088/41d571ac-a679-43d3-9f95-2c3d13ae1534)
