### PR TITLE
Fix typo in neutral element definition with respect to addition in modular arithmetic

### DIFF
--- a/chapters/arithmetics-moonmath.tex
+++ b/chapters/arithmetics-moonmath.tex
@@ -673,7 +673,7 @@ For example, the multiplicative inverse of $3$ is $\frac{1}{3}$, since $3\cdot \
 \end{example}
 \begin{example}Looking at  the set $\Z$ of integers, we see that the neutral element of multiplication is the number $1$ We can also see that no integer other than $1$ or $-1$ has a multiplicative inverse, since the equation $a\cdot x =1$ has no integer solutions for $a\neq 1$ or $a\neq -1$.
 
-The definition of multiplicative inverse has an analog definition for addition called the \term{additive inverse}. In the case of integers, the neutral element with respect to addition is $0$, since $a+0=0$ for all integers $a\in\Z$. The additive inverse always exists, and is given by the negative number $-a$, since $a+(-a)=0$.
+The definition of multiplicative inverse has an analog definition for addition called the \term{additive inverse}. In the case of integers, the neutral element with respect to addition is $0$, since $a+0=a$ for all integers $a\in\Z$. The additive inverse always exists, and is given by the negative number $-a$, since $a+(-a)=0$.
 \end{example}
 \begin{example} Looking at the set $\Z_6$ of residue classes modulo $6$ from \examplename{} \ref{def_residue_ring_z_6}, we can use the multiplication table in \eqref{eq:Z6_tables} to find multiplicative inverses. To do so, we look at the row of the element and find the entry equal to $1$. If such an entry exists, the element of that column is the multiplicative inverse. If, on the other hand, the row has no entry equal to $1$, we know that the element has no multiplicative inverse.
 


### PR DESCRIPTION
Fixes typo for definition of neutral element with respect to addition.
Expectedly $a+0=a$, $\forall a \in\mathbb{Z}$

```diff
- $a+0=0$
+ $a+0=a$
```