### PR TITLE
Definition 4.1.0.1: Introduce $g^{-1}$ in terms of $e$, not vice versa.

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -24,7 +24,7 @@ A \term{commutative group} $(\G,\cdot) $ consists of a set $\G$ and a \term{map}
 \item \hilight{Associativity}: For every $g_1,g_2,g_3\in\G$ the equation
 $g_1\cdot(g_2\cdot g_3) = (g_1\cdot g_2)\cdot g_3$ holds.
 \item \hilight{Existence of a neutral element}:  For every $g\in\G$, there is an $e\in\G$ such that $e\cdot g=g$.
-\item \hilight{Existence of an inverse}: For every $g\in\G$, there is an $e\in\G$ such that $g\cdot g^{-1}=e$.
+\item \hilight{Existence of an inverse}: For every $g\in\G$, there is an $g^{-1}\in\G$ such that $g\cdot g^{-1}=e$.
 \end{itemize}
 If $(\G,\cdot)$ is a group, and $\G'\subset\G$ is a subset of $\G$ such that the \term{restriction} of the group law $\cdot: \G'\times \G' \to \G'$ is a group law on $\G'$, then $(\G',\cdot)$ is called a \term{subgroup} of $(\G,\cdot)$.
 \end{definition}


### PR DESCRIPTION
The $e$ is introduced by "Existence of a neutral element". 

"Existence of inverse" goes after it, so I think it would be logical to express $g^{-1}$ in terms of $e$.