### PR TITLE
Fix typo

### DIFF
--- a/chapters/arithmetics-moonmath.tex
+++ b/chapters/arithmetics-moonmath.tex
@@ -986,7 +986,7 @@ sage: P*Q == Z6x(5*x^5 +4*x^4 +4*x^3+3*x^2+4*x +4)
 \end{sagecommandline}
 \end{example}
 \begin{exercise}
-Compare the sum $P+Q$ and the product $P\cdot Q$ from the previous two examples \ref{example:integer_polynomial_arithmetic_1} and \ref{example:integer_mod_6_polynomial_arithmetic_1}, and consider the definition of $\Z_6$ as given in \examplename{} \ref{def_residue_ring_z_6}. How can we derive the computations in $\Z_6[x]$ from the computations in $Z[x]$?
+Compare the sum $P+Q$ and the product $P\cdot Q$ from the previous two examples \ref{example:integer_polynomial_arithmetic_1} and \ref{example:integer_mod_6_polynomial_arithmetic_1}, and consider the definition of $\Z_6$ as given in \examplename{} \ref{def_residue_ring_z_6}. How can we derive the computations in $\Z_6[x]$ from the computations in $\Z[x]$?
 \end{exercise}
 \subsection{\concept{Euclidean division} with polynomials}
 The arithmetic of polynomials shares a lot of properties with the arithmetic of integers. As a consequence, the concept of \concept{Euclidean division} and the algorithm of long division is also defined for polynomials. Recalling the \concept{Euclidean division} of integers \ref{Euclidean_division}, we know that, given two integers $a$ and $b\neq 0$, there is always another integer $m$ and a natural number $r$ with $r<|b|$ such that $a = m\cdot b +r$ holds.


### PR DESCRIPTION
A missing backslash leads to the ring of integers being displayed as an italic Z. This commit adds this missing backslash to display the ring of integers correctly.