### PR TITLE
Complete Example 45

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -457,9 +457,9 @@ $s||s'=<b_1,b_2,\ldots,b_k,b'_1,b'_2,\ldots,b'_l>$.
 If $H$ is a hash function that maps binary strings of arbitrary length onto binary strings of length $k$, and $s\in\{0,1\}^*$ is a binary string, we write $H(s)_j$ for the bit at position $j$ in the image $H(s)$.
 \end{notation}
 
-\begin{example}[$k$-truncation hash]\label{ex:k-truncation-hash} One of the most basic hash functions $H_k:\{0,1\}^*\to \{0,1\}^k$ is given by simply truncating every binary string $s$ of size $|s|> k$ to a string of size $k$ and by filling any string $s'$ of size $|s'|<k$ with zeros. To make this hash function deterministic, we define that both truncation and filling should happen ``on the left''.
+\begin{example}[$k$-truncation hash]\label{ex:k-truncation-hash} One of the most basic hash functions $H_k:\{0,1\}^*\to \{0,1\}^k$ is given by simply truncating every binary string $s$ of size $|s|> k$ to a string of size $k$ and by filling any string $s'$ of size $|s'|<k$ with zeros. To make this hash function deterministic, we define that both truncation and filling should happen on the highest bits, or ``on the left''.
 
-For example, if the parameter $k$ is given by $k=3$, $s_1=<0,0,0,0,1,0,1,0,1,1,1,0>$ and $s_2=1$, then \smecomb{$H_3(s_1)=<1,1,0>$ and $H_3(s_2)=<0,0,1>$}.
+For example, if the parameter $k$ is given by $k=3$, $s_1=<0,0,0,0,1,0,1,0,1,1,1,0>$ and $s_2=1$, then $H_3(s_1)=<1,1,0>$ and $H_3(s_2)=<0,0,1>$.
 \end{example}
 
 A desirable property of a hash function is \term{uniformity}, which means that it should map input values as evenly as possible over its output range. In mathematical terms, every string of length $k$  from $\{0,1\}^k$ should be generated with roughly the same probability.


### PR DESCRIPTION
Example 45 is truncated because the answer is commented out. Fix this and add slightly more precise language defining "on the left"

The example is truncated in at least the v1.1.1 and v1.1.2 pdfs.