### PR TITLE
Fix subscript off-by-one in Equation 4.38

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -900,7 +900,7 @@ H6 = list_plot(arr4, ymin=0,ymax=10000,color='black', legend_label='k2=16')
 A third method that can sometimes be found in implementations is the so-called \term{``try-and-increment'' method}. To understand this method, we define an integer $z\in\Z$ from any hash value $H(s)$ as we did in the previous methods:
 
 \begin{equation}
-z = H(s)_0\cdot 2^0 + H(s)_1\cdot 2^1 + \ldots + H(s)_{k-1}\cdot 2^{k}
+z = H(s)_0\cdot 2^0 + H(s)_1\cdot 2^1 + \ldots + H(s)_{k}\cdot 2^{k}
 \end{equation}
 
 Hashing into $\Z_n$ is then achievable by first computing $z$, and then trying to see if $z\in\Z_n$. If it is, then the hash is done; if not, the string $s$ is modified in a deterministic way and the process is repeated until a suitable element $z\in\Z_n$ is found. A suitable, deterministic modification could be to concatenate the original string by some bit counter. A ``try-and-increment'' algorithm would then work like in \algname{} \ref{alg_try_and_increment}.


### PR DESCRIPTION
Equation 4.38 for the try-and-increment has a mismatch between the subscript and the exponent of the last power-of-two dimension. Change the subscript to match the exponent, which now matches the algorithm for `try-and-increment`