### PR TITLE
fix font of Z_4 in Pedersen Hash section

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -574,10 +574,10 @@ From an implementation perspective, it is important to derive the set of generat
 
 \begin{example} To compute an actual Pedersen’s  hash, consider the cyclic group $\Z^*_{5}$ from \examplename{} \ref{example:cyclic_group_F5*}. We know from \examplename{} \ref{example:factor_groupds_of_F*5} that the elements $2$ and $3$ are generators of  $\Z^*_{5}$, and it follows that the following map is a Pedersen's hash function:
 \begin{equation}
-H_{\{2,3\}}: \Z_4 \times Z_4 \to \Z^*_{5}\;;\; (x,y)\mapsto 2^x \cdot 3^y
+H_{\{2,3\}}: \Z_4 \times \Z_4 \to \Z^*_{5}\;;\; (x,y)\mapsto 2^x \cdot 3^y
 \end{equation}
 
-To see how this map can be calculated, we choose the input value $(1,3)$ from $\Z_4 \times Z_4$. Then, using the multiplication table from \eqref{Z5_tables}, we calculate $H_{\{2,3\}}(1,3)= 2^1\cdot 3^3= 2\cdot 2 =4$. 
+To see how this map can be calculated, we choose the input value $(1,3)$ from $\Z_4 \times \Z_4$. Then, using the multiplication table from \eqref{Z5_tables}, we calculate $H_{\{2,3\}}(1,3)= 2^1\cdot 3^3= 2\cdot 2 =4$. 
 
 To see how the composition of a hash function with $H_{\{2,3\}}$ defines a hash-to-group function, consider the $SHA256$ hash function from example \ref{ex:SHA256}. Given some binary string $s\in\{0,1\}^*$, we can insert the two least significant bits $SHA256(s)_0$ and $SHA256(s)_1$ from the image $SHA256(s)$ into $H_{\{2,3\}}$ to get an element in $\F_5^*$. This defines the following hash-to-group function
 $$


### PR DESCRIPTION
two instances are missing the leading \ and therefore rendering incorrectly in the pdf