### PR TITLE
consistent capitalization of irreducible polynomial symbol

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -1169,7 +1169,7 @@ The addition law of the prime field extension $\F_{p^m}$ is given by the usual a
 \begin{equation}
 +:\; \F_{p^m}\times \F_{p^m} \to \F_{p^m}\; , \textstyle (\sum_{j=0}^m a_j x^j,\sum_{j=0}^m b_j x^j)\mapsto \sum_{j=0}^m (a_j+b_j) x^j
 \end{equation}
-The multiplication law of the prime field extension $\F_{p^m}$ is given by first multiplying the two polynomials as defined in \eqref{def:polynomial_arithmetic_mul},  then dividing the result by the irreducible polynomial $p$ and keeping the remainder:
+The multiplication law of the prime field extension $\F_{p^m}$ is given by first multiplying the two polynomials as defined in \eqref{def:polynomial_arithmetic_mul},  then dividing the result by the irreducible polynomial $P$ and keeping the remainder:
 \begin{equation}
 \cdot : \; \F_{p^m}\times \F_{p^m} \to \F_{p^m}\; , \textstyle\; (\sum_{j=0}^m a_j x^j,\sum_{j=0}^m b_j x^j)\mapsto \Zmod{\left(\sum _{n = 0} ^{2m} \sum _{i = 0} ^{n}{a} _{i }{{b} _{n-i}}{x} ^{n}\right)}{P}
 \end{equation}


### PR DESCRIPTION
It's defined as capital P and referenced as lower-case p, which conflict the prime number p