### PR TITLE
fix sum range in equation for the addition law of prime field extentions

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -1167,7 +1167,7 @@ The set $\F_{p^m}$ of the prime field extension is given by the set of all polyn
 \end{equation}
 The addition law of the prime field extension $\F_{p^m}$ is given by the usual addition of polynomials as defined in \eqref{def:polynomial_arithmetic}: 
 \begin{equation}
-+:\; \F_{p^m}\times \F_{p^m} \to \F_{p^m}\; , \textstyle (\sum_{j=0}^m a_j x^j,\sum_{j=0}^m b_j x^j)\mapsto \sum_{j=0}^m (a_j+b_j) x^j
++:\; \F_{p^m}\times \F_{p^m} \to \F_{p^m}\; , \textstyle (\sum_{j=0}^m-1 a_j x^j,\sum_{j=0}^m-1 b_j x^j)\mapsto \sum_{j=0}^m-1 (a_j+b_j) x^j
 \end{equation}
 The multiplication law of the prime field extension $\F_{p^m}$ is given by first multiplying the two polynomials as defined in \eqref{def:polynomial_arithmetic_mul},  then dividing the result by the irreducible polynomial $p$ and keeping the remainder:
 \begin{equation}


### PR DESCRIPTION
Currently the summand upper bounds are `m`, but largest order in the field extension definition is `m-1`.

This fixes the summation.