### PR TITLE
Fix typo in 'Unsigned Integer Operators'

### DIFF
--- a/chapters/circuit-compilers-moonmath.tex
+++ b/chapters/circuit-compilers-moonmath.tex
@@ -1558,7 +1558,7 @@ During the setup-phase, a circuit compiler might then replace any occurrence of 
 \end{center}
 During the prover phase, the function \texttt{main} is called with an actual input of \texttt{u4} type, say \texttt{x=14}. The Prover then has to transform the decimal value $14$ into its $4$-bit binary representation $Bits(14)_2 = <0,1,1,1>$ outside of the circuit. Then the array of field values $x[4] = [0,1,1,1]$ is used as an input to the circuit. Since all $4$ field elements are either $0$ or $1$, the four boolean constraints are satisfied and the output is a ring shift of the input array of the four field elements given by $[1,1,1,0]$, which represents the \texttt{u4} element $7$. 
 \end{example}
-\paragraph{The Unigned Integer Operators} Since elements of \texttt{uN} type are represented as boolean arrays, shift operators are implemented in circuits simply by rewiring the boolean input variables to the output variables accordingly. 
+\paragraph{The Unsigned Integer Operators} Since elements of \texttt{uN} type are represented as boolean arrays, shift operators are implemented in circuits simply by rewiring the boolean input variables to the output variables accordingly. 
 
 Logical operators, like \texttt{AND}, \texttt{OR}, or \texttt{NOT} are defined on the \texttt{uN} type by invoking the appropriate boolean operators bitwise to every bit in the boolean array that represents the \texttt{uN} element.
 


### PR DESCRIPTION
Just a typo in word "Unsigned"