### PR TITLE
fix: inconsistency in definition of congruence

### DIFF
--- a/chapters/arithmetics-moonmath.tex
+++ b/chapters/arithmetics-moonmath.tex
@@ -384,7 +384,7 @@ We can formalize this intuition of what congruence should be into a proper defin
 
 If, on the other hand, two numbers are not congruent with respect to a given modulus $n$, we call them \term{incongruent} w.r.t. $n$.
 
-In other words, \term{congruence} is an equation ``up to congruence'', which means that the equation only needs to hold if we take the modulus of both sides. This is expressed with the following notation:
+In other words, \term{congruence} is an equation ``up to a modulus'', which means that the equation only needs to hold if we take the modulus of both sides. This is expressed with the following notation:
 \footnote{A more in-depth introduction to the notion of congruency and its basic properties and
 application in number theory can be found in \chaptname{} 5 of \cite{hardy-2008}.}
 \begin{equation}


### PR DESCRIPTION
Section 3.3.1 defines congruence as `an equation “up to congruence”` but then section 3.3.2 defines it as `an equation “up to a modulus”` which seems like the appropriate definition.