### PR TITLE
remove unnecessary subscripts for the x, y parameters

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -884,8 +884,8 @@ sage: MTJJ == IINV_WTJJ
 \item (Tangent rule) If $P=(x,y)$ with $y\neq 0$, the group law $P\oplus P=(x',y')$ is defined as follows:
 $$
 \begin{array}{llr}
-x' = (\frac{3x_1^2 + 2A x_1 +1}{2By_1})^2\cdot B - (x_1 + x_2) - A &,&
-y' = \frac{3x_1^2 + 2A x_1 +1}{2By_1}(x_1-x') - y_1
+x' = (\frac{3x^2 + 2A x +1}{2By})^2\cdot B - 2x - A &,&
+y' = \frac{3x^2 + 2A x +1}{2By}(x-x') - y
 \end{array} 
 $$
 \item (Chord rule) If $P=(x_1,y_1)$ and $Q=(x_2,y_2)$ such that $x_1 \neq x_2$, the group law $R=P\oplus Q$ with $R=(x_3,y_3)$ is defined as follows:


### PR DESCRIPTION
The tangent rule apply to a single point P=(x,y) but the equation was written as though there are 2 points (x_1,y_1), (x_2,y_2)

This change simplifies the equation, matching the inline notation of `P=(x,y)` as well as the notation using the tangent definition for the Weierstrass form