### PR TITLE
use consistent notation for the resultant point of the chord rule

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -888,7 +888,7 @@ x' = (\frac{3x_1^2 + 2A x_1 +1}{2By_1})^2\cdot B - (x_1 + x_2) - A &,&
 y' = \frac{3x_1^2 + 2A x_1 +1}{2By_1}(x_1-x') - y_1
 \end{array} 
 $$
-\item (Chord rule) If $P=(x_1,y_1)$ and $Q=(x_2,y_2)$ such that $x_1 \neq x_2$, the group law $R=P\oplus Q$ with $R=(x_3,y_3)$ is defined as follows:
+\item (Chord rule) If $P=(x_1,y_1)$ and $Q=(x_2,y_2)$ such that $x_1 \neq x_2$, the group law $R=P\oplus Q$ with $R=(x',y')$ is defined as follows:
 $$
 \begin{array}{llr}
 x' = (\frac{y_2-y_1}{x_2-x_1})^2B - (x_1 + x_2) - A &, &


### PR DESCRIPTION
The existing mixes (x_3,y_3) and (x',y') as the coordinates of the resultant point of the Montmogery chord rule.

This change uses (x',y') everywhere, to be consistent with previous definition in the text
