### PR TITLE
use E_{1,1}(\F_5) everywhere

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -171,7 +171,7 @@ sage: r.nbits()
 \end{sagecommandline}
 \end{example}
 
-\begin{exercise} Consider the curve $E_1(\F)$ from \examplename{} \ref{E1F5} and compute the set of all curve points $(x,y)\in E_1(\F)$.
+\begin{exercise} Consider the curve $E_{1,1}(\F_5)$ from \examplename{} \ref{E1F5} and compute the set of all curve points $(x,y)\in E_{1,1}(\F_5)$.
 \end{exercise}
 \begin{exercise} Consider the curve $TJJ\_13$ from \examplename{} \ref{TJJ13} and compute the set of all curve points $(x,y)\in TJJ\_13$.
 \end{exercise}
@@ -201,7 +201,7 @@ E_{1,4}(\F_5) = \{
 \Oinf, (0,2), (0,3), (1,1), (1,4), (2,2), (2,3), (3,2), (3,3)\}
 \end{equation}
 
-As we can see, both curves are of the same order. Since $2$ is an invertible element from $\F_5$ with $1 = 2^4\cdot 1$ and $4=2^6\cdot 1$, $E_{1,4}(\F)$ and $E_{1,1}(\F)$ are isomorphic: the map $I: E_{1,1}(\F_5)\to E_{1,4}(\F_5): (x,y)\mapsto (4x,3y)$ from \ref{eq:curve_isomorphism} defines a 1:1 correspondence. For example, the point $(4,3)\in E_{1,1}(\F)$ is mapped onto the point $I(4,3)=(4\cdot 4, 3\cdot 3) = (1,4)\in E_{1,4}(\F)$.
+As we can see, both curves are of the same order. Since $2$ is an invertible element from $\F_5$ with $1 = 2^4\cdot 1$ and $4=2^6\cdot 1$, $E_{1,4}(\F_5)$ and $E_{1,1}(\F_5)$ are isomorphic: the map $I: E_{1,1}(\F_5)\to E_{1,4}(\F_5): (x,y)\mapsto (4x,3y)$ from \ref{eq:curve_isomorphism} defines a 1:1 correspondence. For example, the point $(4,3)\in E_{1,1}(\F_5)$ is mapped onto the point $I(4,3)=(4\cdot 4, 3\cdot 3) = (1,4)\in E_{1,4}(\F)$.
 \end{example}
   
 \begin{exercise}
@@ -477,7 +477,7 @@ Using the generator $(0,1)$ and its associated exponential map, we can write $E(
 \begin{equation}
 E_{1,1}(\F_5) = \{(0, 1)\to (4, 2)\to (2, 1)\to (3, 4)\to (3, 1)\to (2, 4)\to (4, 3)\to (0, 4)\to \Oinf \}
 \end{equation}
-This indicates that the first element is a generator, and the $n$-th element is the scalar product of $n$ and the generator. To see how logarithmic orders like this simplify the computations in small elliptic curve groups, consider \examplename{} \ref{ex:01+42} again. In that example, we use the chord-and-tangent rule to compute $(0,1)\oplus (4,2)$. Now, in the logarithmic order of $E_1(\F)$, we can compute that sum much easier, since we can directly see that $(0,1)=[1](0,1)$ and $(4,2)=[2](0,1)$. We can then deduce $(0,1)\oplus (4,2)= (2,1)$ as follows:
+This indicates that the first element is a generator, and the $n$-th element is the scalar product of $n$ and the generator. To see how logarithmic orders like this simplify the computations in small elliptic curve groups, consider \examplename{} \ref{ex:01+42} again. In that example, we use the chord-and-tangent rule to compute $(0,1)\oplus (4,2)$. Now, in the logarithmic order of $E_{1,1}(\F_5)$, we can compute that sum much easier, since we can directly see that $(0,1)=[1](0,1)$ and $(4,2)=[2](0,1)$. We can then deduce $(0,1)\oplus (4,2)= (2,1)$ as follows:
 
 \begin{equation}
 (0,1)\oplus (4,2)=[1](0,1)\oplus [2](0,1)= [3](0,1)=(2,1)
@@ -592,7 +592,7 @@ All points that remain are the affine points $[X:Y:1]$. Inserting all of them in
 
 \begin{multline}
 \label{E1F5_projective_points_set}
-E_1(\F_5\mathrm{P}^2)=\{[0:1:0], [0:1:1], [2:1:1], [3:1:1], \\ [4:2:1], [4:3:1], [0:4:1], [2:4:1], [3:4:1]\}
+E_{1,1}(\F_5\mathrm{P}^2)=\{[0:1:0], [0:1:1], [2:1:1], [3:1:1], \\ [4:2:1], [4:3:1], [0:4:1], [2:4:1], [3:4:1]\}
 \end{multline}
 
 If we compare this with the affine representation, we see that there is a 1:1 correspondence between the points in the affine representation in \eqref{eq:E1F5-affine} and the affine points in projective geometry, and that the projective point $[0:1:0]$ represents the additional point $\Oinf$ in the affine representation.
@@ -671,14 +671,14 @@ It can be shown that the points of an elliptic curve in projective space form a 
 
 %So we assume that there is some trusted third party $C$ that chooses a publicly known generator of a large prime-order subgroup of $TJJ(\F_{13})$, say  a secrete point $s\in\F_{13}$, say $s=2$. $C$ then c
 %\end{example}
-\begin{exercise} Consider \examplename{} \ref{ex:E1F5-projective} again. Compute the following expression for projective points on $E_1(\F_5\mathrm{P}^2)$ using \algname{} \ref{alg:projective_group_law}:
+\begin{exercise} Consider \examplename{} \ref{ex:E1F5-projective} again. Compute the following expression for projective points on $E_{1,1}(\F_5\mathrm{P}^2)$ using \algname{} \ref{alg:projective_group_law}:
 \begin{itemize}
 \item $[0:1:0]\oplus [4:3:1]$
 \item $[0:3:0]\oplus [3:1:2]$
 \item $-[0:4:1]\oplus [3:4:1]$
 \item $[4:3:1]\oplus [4:2:1]$
 \end{itemize}
-and then solve the equation $[X:Y:Z] \oplus [0:1:1]= [2:4:1]$ for some point $[X:Y:Z]$ from the projective \concept{short Weierstrass} curve $E_1(\F_5\mathrm{P}^2)$.
+and then solve the equation $[X:Y:Z] \oplus [0:1:1]= [2:4:1]$ for some point $[X:Y:Z]$ from the projective \concept{short Weierstrass} curve $E_{1,1}(\F_5\mathrm{P}^2)$.
 \end{exercise}
 
 \begin{exercise}
@@ -810,7 +810,7 @@ sage: # does not compute the point at infinity
 Consider \examplename{} \ref{TJJ13-montgomery} and compute the set in \eqref{tjj_13_montgomery_points_set} by inserting every pair of field elements $(x,y)\in \F_{13}\times \F_{13}$ into the defining Montgomery equation.
 \end{exercise}
 \begin{exercise}
-Consider the elliptic curve $E_1(\F)$ from \examplename{} \ref{E1F5} and show that $E_1(\F)$ is not a Montgomery curve.
+Consider the elliptic curve $E_{1,1}(\F_5)$ from \examplename{} \ref{E1F5} and show that $E_{1,1}(\F_5)$ is not a Montgomery curve.
 \end{exercise}
 \begin{exercise}
 Consider the elliptic curve \curvename{secp256k1} from \examplename{} \ref{secp256k1} and show that \curvename{secp256k1} is not a Montgomery curve.
@@ -1183,9 +1183,9 @@ While we did not change the defining parameters, we consider curve points from t
 
 \begin{example}\label{ex:EF52} Consider the prime field $\F_5$ from \examplename{} \ref{prime-field-F5} together with the elliptic curve $E_{1,1}(\F_5)$ and its definition from \examplename{} \ref{E1F5} and the construction the extension field $\F_{5^2}$ relative to the polynomial $t^2+2 \in \F_5[t]$ from exercise \ref{exercise:finite_fieldF5_2}. In this example we extend the definition of $E_{1,1}(\F_5)$ to an elliptic curve over $\F_{5^2}$ and compute its set of points:
 $$
-E_1(\F_{5^2}) = \{ (x,y)\in \F_{5^2}\times \F_{5^2} \;|\; y^2 = x^3 + x +1 \}
+E_{1,1}(\F_{5^2}) = \{ (x,y)\in \F_{5^2}\times \F_{5^2} \;|\; y^2 = x^3 + x +1 \}
 $$
-Since $\F_{5^2}$ contains $25$ points, in order to compute the set $E_1(\F_{5^2})$, we have to try $25\cdot 25 = 625$ pairs, which is probably a bit tedious. Instead, we use Sage to compute the curve for us. To do, we choose the representation of $\F_{5^2}$ from \ref{exercise:finite_fieldF5_2}. We get:
+Since $\F_{5^2}$ contains $25$ points, in order to compute the set $E_{1,1}(\F_{5^2})$, we have to try $25\cdot 25 = 625$ pairs, which is probably a bit tedious. Instead, we use Sage to compute the curve for us. To do, we choose the representation of $\F_{5^2}$ from \ref{exercise:finite_fieldF5_2}. We get:
 \begin{sagecommandline}
 sage: F5= GF(5)
 sage: F5t.<t> = F5[] 
@@ -1195,9 +1195,9 @@ sage: F5_2.<t> = GF(5^2, name='t', modulus=P_MOD_2)
 sage: E1F5_2 = EllipticCurve(F5_2,[1,1])
 sage: E1F5_2.order()
 \end{sagecommandline}
-The curve $E_1(\F_{5^2})$ consist of $27$ points, in contrast to curve $E_1(\F_{5})$, which consists of $9$ points. Writing those points down gives the following:
+The curve $E_{1,1}(\F_{5^2})$ consist of $27$ points, in contrast to curve $E_{1,1}(\F_{5})$, which consists of $9$ points. Writing those points down gives the following:
 \begin{multline*}
-E_1(\F_{5^2}) = \{\Oinf, (0, 4), (0, 1), (3, 4), (3, 1), (4, 3), (4, 2), (2, 4), (2, 1),\\ 
+E_{1,1}(\F_{5^2}) = \{\Oinf, (0, 4), (0, 1), (3, 4), (3, 1), (4, 3), (4, 2), (2, 4), (2, 1),\\ 
 (4t + 3, 3t + 4), (4t + 3, 2t + 1),  (3t + 2, t), (3t + 2, 4t),\\ 
 (2t + 2, t), (2t + 2, 4t), (2t + 1, 4t + 4), (2t + 1, t + 1),\\ 
 (2t + 3, 3), (2t + 3, 2), (t + 3, 2t + 4), (t + 3, 3t + 1),\\ 
@@ -1247,9 +1247,9 @@ So, when we consider nested elliptic curve extensions as in \ref{def:full_torsio
 
 \begin{example}
 \label{example:E1_full_torsion}
- Consider curve $E_{1,1}(\F_5)$ again. We know from \ref{ex:G1G2-subgroups} that it contains a $3$-torsion group and that the embedding degree of $3$ is $k(3)=2$. From this we can deduce that we can find the full $3$-torsion group $E_1[3]$ in the curve extension $E_1(\F_{5^2})$, the latter of which we computed in \examplename{} \ref{ex:EF52}. 
+ Consider curve $E_{1,1}(\F_5)$ again. We know from \ref{ex:G1G2-subgroups} that it contains a $3$-torsion group and that the embedding degree of $3$ is $k(3)=2$. From this we can deduce that we can find the full $3$-torsion group $E_{1,1}[3]$ in the curve extension $E_{1,1}(\F_{5^2})$, the latter of which we computed in \examplename{} \ref{ex:EF52}. 
 
-Since that curve is small, in order to find the full $3$-torsion, we can loop through all elements of $E_1(\F_{5^2})$ and check the defining equation $[3]P= \Oinf$. Invoking Sage and using our implementation of $E_1(\F_{5^2})$ in sage from \ref{ex:EF52}, we compute as follows:
+Since that curve is small, in order to find the full $3$-torsion, we can loop through all elements of $E_{1,1}(\F_{5^2})$ and check the defining equation $[3]P= \Oinf$. Invoking Sage and using our implementation of $E_{1,1}(\F_{5^2})$ in sage from \ref{ex:EF52}, we compute as follows:
 \begin{sagecommandline}
 sage: INF = E1F5_2(0) # Point at infinity
 sage: L_E1_3 = []
@@ -1259,9 +1259,9 @@ sage: for p in E1F5_2:
 sage: E1_3 = Set(L_E1_3) # Full 3-torsion set
 \end{sagecommandline}
 $$
-E_1[3] = \{\Oinf,(2,1),(2,4),(1,t),(1,4t), (2t + 1,t + 1), (2t + 1, 4t + 4), (3t + 1,t + 4), (3t + 1, 4t + 1) \}
+E_{1,1}[3] = \{\Oinf,(2,1),(2,4),(1,t),(1,4t), (2t + 1,t + 1), (2t + 1, 4t + 4), (3t + 1,t + 4), (3t + 1, 4t + 1) \}
 $$
-As we can see the group $E_1[3]$ contains $9=3^3$ many elements and the $3$-torsion group $E_{1,1}(\F_5)[3]$ of the curve over the prime field is a subset of the full torsion group. 
+As we can see the group $E_{1,1}[3]$ contains $9=3^3$ many elements and the $3$-torsion group $E_{1,1}(\F_5)[3]$ of the curve over the prime field is a subset of the full torsion group. 
 \end{example}
 \begin{example}\label{ex:TJJ13-full-torsion} HHHH Consider the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13}. We know from \examplename{} \ref{ex:TJJ13-embedding-degree} that it contains a $5$-torsion group and that the embedding degree of $5$ is $4$. This implies that we can find the full $5$-torsion group $\mathit{TJJ\_13}[5]$ in the curve extension $\mathit{TJJ\_13}(\F_{13^4})$. 
 
@@ -1352,11 +1352,11 @@ It should be noted that other definitions of $\G_2$ exists in the literature, to
 
 \begin{example} Consider the curve $E_{1,1}(\F_5)$ from \examplename{} \ref{E1F5} again. As we have seen, this curve has the embedding degree $k=2$, and a full $3$-torsion group is given as follows:
 \begin{multline}
-E_1[3] = \{\Oinf,(2,1),(2,4), (1,t), (1,4t), (2t + 1,t + 1),\\ (2t + 1, 4t + 4),
+E_{1,1}[3] = \{\Oinf,(2,1),(2,4), (1,t), (1,4t), (2t + 1,t + 1),\\ (2t + 1, 4t + 4),
 (3t + 1,t + 4), (3t + 1, 4t + 1) \}
 \end{multline}
 
-According to the general theory, $E_1[3]$ contains $4$ subgroups, and we can characterize the subgroups $\G_1$ and $\G_2$ using the Frobenius endomorphism. Unfortunately, at the time of writing, Sage does not have a predefined Frobenius endomorphism for elliptic curves, so we have to use the Frobenius endomorphism of the underlying field as a temporary workaround. Using our implementation of $E_1[3]$ in sage from \examplename{} \ref{example:E1_full_torsion}, we compute $\G_1$ as follows:
+According to the general theory, $E_{1,1}[3]$ contains $4$ subgroups, and we can characterize the subgroups $\G_1$ and $\G_2$ using the Frobenius endomorphism. Unfortunately, at the time of writing, Sage does not have a predefined Frobenius endomorphism for elliptic curves, so we have to use the Frobenius endomorphism of the underlying field as a temporary workaround. Using our implementation of $E_{1,1}[3]$ in sage from \examplename{} \ref{example:E1_full_torsion}, we compute $\G_1$ as follows:
 \begin{sagecommandline}
 sage: L_G1 = []
 sage: for P in E1_3: 


### PR DESCRIPTION
 There were two symbols to reference the example elliptic curve over F_5 with a=b=1. Most places use E_{1,1}(\F_5) some use E_1(\F_5) and few use E_1(\F)
 
 This change consistently uses E_{1,1}(\F_5) 