### PR TITLE
Correct typos in Chapter 5

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -537,11 +537,11 @@ As we have seen in the previous section, describing elliptic curves as pairs of 
 
 Recalling the definition of projective planes \ref{sec:planes},\sme{S: move that section here?} we know that points at infinity are handled as ordinary points in projective geometry. Therefore, it makes  sense to look at the definition of a \concept{short Weierstrass} curve in projective geometry.
 
-To see what a \concept{short Weierstrass} curve in projective coordinates is, let $\F$ be a finite field of order $q$ and characteristic $>3$, let $a,b\in \F$ be two field elements such that $\Zmod{4a^3+ 27b^2}{q}\neq 0$ and let $\F\mathrm{P}^2$ be the projective plane over $\F$ as introduced in \secname{} \ref{sec:planes}. Then a \term{projective \concept{short Weierstrass} elliptic curve} over $\F$ is the set of all points $[X:Y:Z]\in \F\mathrm{P}^2$ from the projective plane that satisfy the cubic equation $Y^2\cdot Z = X^3+a\cdot X\cdot Z^2 + b\cdot Z^3$:
+To see what a \concept{short Weierstrass} curve in projective coordinates is, let $\F$ be a finite field of order $q$ and characteristic $>3$, let $a,b\in \F$ be two field elements such that $\Zmod{4a^3+ 27b^2}{q}\neq 0$ and let $\F\mathbb{P}^2$ be the projective plane over $\F$ as introduced in \secname{} \ref{sec:planes}. Then a \term{projective \concept{short Weierstrass} elliptic curve} over $\F$ is the set of all points $[X:Y:Z]\in \F\mathbb{P}^2$ from the projective plane that satisfy the cubic equation $Y^2\cdot Z = X^3+a\cdot X\cdot Z^2 + b\cdot Z^3$:
 
 \begin{equation}
 \label{def:projective_cubic_equation}
-E(\F\mathrm{P}^2) = \{[X:Y:Z]\in \F\mathrm{P}^2\;|\; Y^2\cdot Z = X^3+a\cdot X\cdot Z^2 + b\cdot Z^3 \}
+E(\F\mathbb{P}^2) = \{[X:Y:Z]\in \F\mathbb{P}^2\;|\; Y^2\cdot Z = X^3+a\cdot X\cdot Z^2 + b\cdot Z^3 \}
 \end{equation}
 
 To understand how the point at infinity is unified in this definition, recall from \secname{} \ref{sec:planes} that, in projective geometry, points at infinity are given by projective coordinates $[X:Y:0]$. Inserting representatives $(x_1,y_1,0)\in [X:Y:0]$ from those coordinates into the defining cubic equation \ref{def:projective_cubic_equation} results in the following identity:
@@ -688,10 +688,10 @@ Compare the affine addition law for \concept{short Weierstrass} curves with the 
 \subsubsection{Coordinate Transformations} As we can see by comparing the examples 
 \ref{ex:E1F5-projective} and \ref{ex:E1F5-projective},\sme{same example twice} there is a close relation between the affine and the projective representation of a \concept{short Weierstrass} curve. This is not a coincidence. In fact, from a mathematical point of view, projective and affine \concept{short Weierstrass} curves describe the same thing, as there is a one-to-one correspondence (an isomorphism) between both representations for any parameters $a$ and $b$. 
 
-To specify the correspondence, let $E(\F)$ and $E(\F\mathrm{P}^2)$ be an affine and a projective \concept{short Weierstrass} curve defined for the same parameters $a$ and $b$. Then, the function in \eqref{eq:weierstrass-isomorphism-map} maps points from the affine representation to points from the projective representation of a \concept{short Weierstrass} curve. In other words, if the pair of field elements $(x,y)$ satisfies the affine \concept{short Weierstrass} equation $y^2= x^3 + ax + b$, then all homogeneous coordinates $(x_1,y_1,z_1)\in [x:y:1]$ satisfy the projective \concept{short Weierstrass} equation $y_1^2\cdot z_1= x_1^3 + ay_1\cdot z_1^2 + b\cdot z_1^3$. 
+To specify the correspondence, let $E(\F)$ and $E(\F\mathbb{P}^2)$ be an affine and a projective \concept{short Weierstrass} curve defined for the same parameters $a$ and $b$. Then, the function in \eqref{eq:weierstrass-isomorphism-map} maps points from the affine representation to points from the projective representation of a \concept{short Weierstrass} curve. In other words, if the pair of field elements $(x,y)$ satisfies the affine \concept{short Weierstrass} equation $y^2= x^3 + ax + b$, then all homogeneous coordinates $(x_1,y_1,z_1)\in [x:y:1]$ satisfy the projective \concept{short Weierstrass} equation $y_1^2\cdot z_1= x_1^3 + ay_1\cdot z_1^2 + b\cdot z_1^3$. 
 
 \begin{equation}\label{eq:weierstrass-isomorphism-map}
-I : E(\F) \to E(\F\mathrm{P}^2)\;:\;
+I : E(\F) \to E(\F\mathbb{P}^2)\;:\;
 \begin{array}{lcl}
 (x,y)       &\mapsto & [x:y:1]\\
 \mathcal{O} &\mapsto & [0:1:0]
@@ -1002,7 +1002,7 @@ To see what the \concept{twisted Edwards} group law looks like, let $(x_1, y_1)$
 (x_1, y_1) \oplus (x_2, y_2) =\left(\frac{x_1y_2+y_1x_2}{1 +dx_1x_2y_1y_2},\frac{y_1y_2-ax_1x_2}{1-dx_1x_2y_1y_2}\right)
 \end{equation}
 
-In order to see what the neutral element of the group law is, first observe that the point $(0,1)$ is a solution to the \concept{twisted Edwards} equation $a\cdot x^{2} + y^2 =1+ d\cdot x^{2}\cdot y^2$ for any parameters $a$ an $d$, and hence $(0,1)$ is a point on any \concept{twisted Edwards} curve. It can be shown that $(0,1)$ serves as the neutral element, and that the inverse of a point $(x_1, y_1)$ is given by the point $(-x_1, y1)$.
+In order to see what the neutral element of the group law is, first observe that the point $(0,1)$ is a solution to the \concept{twisted Edwards} equation $a\cdot x^{2} + y^2 =1+ d\cdot x^{2}\cdot y^2$ for any parameters $a$ an $d$, and hence $(0,1)$ is a point on any \concept{twisted Edwards} curve. It can be shown that $(0,1)$ serves as the neutral element, and that the inverse of a point $(x_1, y_1)$ is given by the point $(-x_1, y_1)$.
 \begin{example}
 \label{example:TETJJ13}
  Let's look at the \curvename{Tiny-jubjub} curve in Edwards form from \eqref{TJJ13-twisted-edwards} again. As we have seen, this curve is given by as follows:


### PR DESCRIPTION
Corrected Chapter 5 typos not covered in https://github.com/LeastAuthority/moonmath-manual/pull/111

## Details
* $y1 \Rightarrow y_1$
* $\mathbb{F}\mathrm{P} \Rightarrow \mathbb{FP}$ (Expression consistent with Chapter 4)