### PR TITLE
Capitalize titles, fix formulas, reword sentences

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -23,10 +23,10 @@ A \term{commutative group} $(\G,\cdot) $ consists of a set $\G$ and a \term{map}
 \item \hilight{Commutativity}: For all $g_1,g_2\in\G$, the equation $g_1\cdot g_2=g_2\cdot g_1$ holds.
 \item \hilight{Associativity}: For every $g_1,g_2,g_3\in\G$ the equation
 $g_1\cdot(g_2\cdot g_3) = (g_1\cdot g_2)\cdot g_3$ holds.
-\item \hilight{Existence of a neutral element}:  For every $g\in\G$, there is an $e\in\G$ such that $e\cdot g=g$.
+\item \hilight{Existence of a neutral element}: For every $g\in\G$, there is an $e\in\G$ such that $e\cdot g=g$.
 \item \hilight{Existence of an inverse}: For every $g\in\G$, there is an $g^{-1}\in\G$ such that $g\cdot g^{-1}=e$.
 \end{itemize}
-If $(\G,\cdot)$ is a group, and $\G'\subset\G$ is a subset of $\G$ such that the \term{restriction} of the group law $\cdot: \G'\times \G' \to \G'$ is a group law on $\G'$, then $(\G',\cdot)$ is called a \term{subgroup} of $(\G,\cdot)$.
+If $(\G,\cdot)$ is a group, and $\G'\subseteq\G$ is a subset of $\G$ such that the \term{restriction} of the group law $\cdot: \G'\times \G' \to \G'$ is a group law on $\G'$, then $(\G',\cdot)$ is called a \term{subgroup} of $(\G,\cdot)$.
 \end{definition}
 
 Rephrasing the abstract definition in layman's terms, a group is something where we can do computations in a way that resembles the behavior of the addition of integers. Specifically, this means we can combine some element with another element into a new element in a way that is reversible and where the order of combining elements doesn't matter.
@@ -68,7 +68,7 @@ The previous example of a commutative group is a very important one for this boo
 
 Find a condition such that $(\Z^*_n,\cdot)$ is a commutative group, compute the neutral element, give a closed form for the inverse of any element and prove the commutative group axioms.
 \end{exercise}
-\subsection{Finite groups}
+\subsection{Finite Groups}
 \label{sec:finite-groups}
  As we have seen in the previous examples, groups can either contain infinitely many elements (such as integers) or finitely many elements (as for example the remainder class groups $(\Z_n,+)$). To capture this distinction, a group is called a \term{finite group} if the underlying set of elements is finite. In that case, the number of elements of that group is called its \term{order}.\footnote{An introduction to finite groups is given in \chaptname{} 1 of \cite{fuchs-2015}. An introduction from the perspective of cryptography can be found in \chaptname{} 3, \secname{} 8.3.1 of \cite{katz-2007}.}
 \begin{notation}
@@ -85,7 +85,7 @@ Consider the remainder class groups $(\Z_6,+)$ from example \ref{def_residue_rin
 Of course, every group $\G$ has a trivial set of generators, when we just consider every element of the group to be in the generator set. The more interesting question is to find smallest possible generator set for a given group. Of particular interest in this regard are groups that have a generator set that contains a single element only. In this case, there exists a (not necessarily unique) element $g\in\G$ such that every other element from $\G$ can be computed by the repeated combination of $g$ and its inverse $g^{-1}$ only. 
 
 \begin{definition}[\deftitle{Cyclic groups}]\label{cyclic-groups}
-Groups with single, not necessarily unique, generators are called \term{cyclic groups} and any element $g\in \G$ that is able to generate $\G$ is called a \term{generator}.
+A group $\G$ is called a \term{cyclic group} if there exists at least one element $g\in \G$, referred to as a \term{generator}, such that it can generate every element of $G$.
 \end{definition}
 
 \begin{example}
@@ -103,7 +103,7 @@ Consider the group $(\Z_6,+)$ of modular 6 addition from example \ref{def_residu
 \begin{exercise}\label{ex:modulus-prime-group} Let $p\in\mathbb{P}$ be prime number and $(\Z_p^*,\cdot)$ the finite group from exercise \ref{ex:Zn*}. Show that $(\Z_p^*,\cdot)$ is cyclic.
 \end{exercise}
 
-\subsection{The exponential map}
+\subsection{Exponential Maps}
 Observe that, when $\G$ is a cyclic group of order $n$ and $g\in \G$ is a generator of $\G$, then there exists a so-called \textbf{exponential map}, which maps the additive group law of the remainder class group $(\Z_n,+)$ onto the group law of $\G$ in a one-to-one correspondence. The exponential map can be formalized as in \eqref{exponentialmap} below (where $g^x$ means ``multiply $g$ by itself $x$ times'' and $g^0=e_{\G}$).
 
 \begin{equation}\label{exponentialmap}
@@ -146,7 +146,7 @@ Cryptographic applications often utilize finite cyclic groups of a very large or
 \end{algorithm}
 
 Because the exponential map respects the group law, it doesn't matter if we do our computation in $\Z_n$ before we write the result into the exponent of $g$ or afterwards: the result will be the same in both cases. The latter method is usually referred to as doing computations ``in the exponent''. In cryptography in general, and in SNARK development in particular, we often perform computations ``in the exponent'' of a generator.
-\begin{example}\label{ex:in-the-exponent} Consider the multiplicative group $(\Z_{5}^*,\cdot)$ from exercise \ref{fstar}. We know from \ref{ex:modulus-prime-group} that $\Z_{5}^*$ is a cyclic group of order $4$, and that the element $3\in\Z_5^*$ is a generator. This means that we also know that the following map respects the group law of addition in $\Z_4$ and the group law of multiplication in $\Z_5^*$:
+\begin{example}\label{ex:in-the-exponent} Consider the multiplicative group $(\Z_{5}^*,\cdot)$ from exercise \ref{fstar}. We know from \exercisename{} \ref{ex:modulus-prime-group} that $\Z_{5}^*$ is a cyclic group of order $4$, and that the element $3\in\Z_5^*$ is a generator. This means that we also know that the following map respects the group law of addition in $\Z_4$ and the group law of multiplication in $\Z_5^*$:
 $$
 3^{(\cdot)}: \Z_4 \to \Z_5^* \;;\; x \mapsto 3^x
 $$
@@ -385,7 +385,7 @@ From this, it follows that whenever $p$ is a Fermat's prime, the discrete logari
 \end{example}
 \end{comment}
 
-\subsubsection{The decisional Diffie--Hellman assumption}
+\subsubsection{The Decisional Diffie--Hellman Assumption}
 \label{def:DDH-secure}
 
 \begin{definition}
@@ -440,7 +440,7 @@ Several variations and special cases of CDH exist. For example, the \term{square
 
 \subsection{Hashing to Groups}\label{sec:hashing-to-groups}
 % https://crypto.stackexchange.com/questions/78017/simple-hash-into-a-prime-field
-\subsubsection{Hash functions}\label{sec:hash-functions} Generally speaking, a hash function is any function that can be used to map data of arbitrary size to fixed-size values. Since binary strings of arbitrary length are a way to represent data in general, we can understand a \textbf{hash function} as the following map where $\{0,1\}^*$ represents the set of all binary strings of arbitrary but finite length and $\{0,1\}^k$ represents the set of all binary strings that have a length of exactly $k$ bits:
+\subsubsection{Hash Functions}\label{sec:hash-functions} Generally speaking, a hash function is any function that can be used to map data of arbitrary size to fixed-size values. Since binary strings of arbitrary length are a way to represent data in general, we can understand a \textbf{hash function} as the following map where $\{0,1\}^*$ represents the set of all binary strings of arbitrary but finite length and $\{0,1\}^k$ represents the set of all binary strings that have a length of exactly $k$ bits:
 \begin{equation}
 \label{def:hash_function}
 H: \{0,1\}^* \to \{0,1\}^k
@@ -457,18 +457,18 @@ $s||s'=<b_1,b_2,\ldots,b_k,b'_1,b'_2,\ldots,b'_l>$.
 If $H$ is a hash function that maps binary strings of arbitrary length onto binary strings of length $k$, and $s\in\{0,1\}^*$ is a binary string, we write $H(s)_j$ for the bit at position $j$ in the image $H(s)$.
 \end{notation}
 
-\begin{example}[$k$-truncation hash]\label{ex:k-truncation-hash} One of the most basic hash functions $H_k:\{0,1\}^*\to \{0,1\}^k$ is given by simply truncating every binary string $s$ of size $|s|> k$ to a string of size $k$ and by filling any string $s'$ of size $|s'|<k$ with zeros. To make this hash function deterministic, we define that both truncation and filling should happen on the highest bits, or ``on the left''.
+\begin{example}[$k$-truncation hash]\label{ex:k-truncation-hash} One of the most basic hash functions $H_k:\{0,1\}^*\to \{0,1\}^k$ is given by simply truncating every binary string $s$ of size $|s|> k$ to a string of size $k$ and by padding any string $s'$ of size $|s'|<k$ with zeros. To make this hash function deterministic, we define that both truncation and padding should happen on the highest bits, or ``on the left''.
 
-For example, if the parameter $k$ is given by $k=3$, $s_1=<0,0,0,0,1,0,1,0,1,1,1,0>$ and $s_2=1$, then $H_3(s_1)=<1,1,0>$ and $H_3(s_2)=<0,0,1>$.
+For example, if the parameter $k$ is given by $k=3$, $s_1=<0,0,0,0,1,0,1,0,1,1,1,0>$ and $s_2=<1>$, then $H_3(s_1)=<1,1,0>$ and $H_3(s_2)=<0,0,1>$.
 \end{example}
 
 A desirable property of a hash function is \term{uniformity}, which means that it should map input values as evenly as possible over its output range. In mathematical terms, every string of length $k$  from $\{0,1\}^k$ should be generated with roughly the same probability.
 
-Of particular interest are so-called \term{cryptographic} hash functions, which are hash functions that are also \term{one-way functions}, which essentially means that, given a string $y$ from $\{0,1\}^k$ it is infeasible to find a string $x\in\{0,1\}^*$ such that $H(x)=y$ holds. This property is usually called \term{preimage-resistance}.
+Of particular interest are so-called \term{cryptographic} hash functions, which are hash functions that are also \term{one-way functions}, which essentially means that, given a string $y$ from $\{0,1\}^k$ it is infeasible to find a string $x\in\{0,1\}^*$ such that $H(x)=y$ holds. This property is usually called \term{preimage resistance}.
 
-Moreover, if a string $x_1\in\{0,1\}^*$ is given, then it should be infeasible to find another string $x_2\in\{0,1\}^*$ with $x_1\neq x_2$ and $H(x_1)=H_(x_2)$
+Moreover, if a string $x_1\in\{0,1\}^*$ is given, then it should be infeasible to find another string $x_2\in\{0,1\}^*$ with $x_1\neq x_2$ and $H(x_1)=H(x_2)$. This is often referred to as \term{second preimage resistance} property.
 
-In addition, it should be infeasible to find two strings $x_1,x_2 \in\{0,1\}^*$ such that $H(x_1)=H(x_2)$, which is called \term{collision resistance}. It is important to note, though, that collisions always exist, since a function $H: \{0,1\}^* \to \{0,1\}^k$ inevitably maps infinitely many values onto the same hash. In fact, for any hash function with digests of length $k$, finding a preimage to a given digest can always be done using a brute force search in $2^k$ evaluation steps. It should just be practically impossible to compute those values, and statistically very unlikely to generate two of them by chance.
+In addition, it should be infeasible to find two distinct strings $x_1,x_2 \in\{0,1\}^*$ such that $H(x_1)=H(x_2)$, which is called \term{collision resistance}. It is important to note, though, that collisions always exist, since a function $H: \{0,1\}^* \to \{0,1\}^k$ inevitably maps infinitely many values onto the same hash. In fact, for any hash function with digests of length $k$, finding a preimage to a given digest can always be done using a brute force search in $2^k$ evaluation steps. It should just be practically impossible to compute those values, and statistically very unlikely to generate two of them by chance.
 
 A third property of a cryptographic hash function is that small changes in the input string, like changing a single bit, should generate hash values that look completely different from each other. This is called \term{diffusion} or the avalanche effect.
 
@@ -486,7 +486,7 @@ Finally, this hash function does not have a lot of diffusion, as changing bits t
 
 Computing cryptographically secure hash functions in pen-and-paper style is possible but tedious. Fortunately, Sage can import the \term{\code{hashlib}} library, which is intended to provide a reliable and stable base for writing Python programs that require cryptographic functions. The following examples explain how to use \code{hashlib} in Sage.
 
-\begin{example}\label{ex:SHA256}An example of a hash function that is generally believed to be a cryptographically secure hash function is the so-called \term{SHA256} hash, which, in our notation, is a function that maps binary strings of arbitrary length onto binary strings of length $256$:
+\begin{example}\label{ex:SHA256}An example of a hash function that is generally believed to be cryptographically secure is the so-called \term{SHA256}, which, in our notation, is a function that maps binary strings of arbitrary length onto binary strings of length $256$:
 \begin{equation}
 SHA256: \{0,1\}^* \to \{0,1\}^{256}
 \end{equation}
@@ -514,12 +514,12 @@ sage: d.str(10) # decimal representation
 \end{sagecommandline}
 \end{example}
 
-\subsubsection{Hashing to cyclic groups} As we have seen in the previous section, general hash functions map binary strings of arbitrary length onto binary strings of some fixed length. However, it is desirable in various cryptographic primitives to not simply hash to binary strings of fixed length, but to hash into algebraic structures like groups, while keeping (some of) the properties of the hash function, like preimage resistance or collision resistance.
+\subsubsection{Hashing to Cyclic Groups} As we have seen in the previous section, general hash functions map binary strings of arbitrary length onto binary strings of some fixed length. However, it is desirable in various cryptographic primitives to not simply hash to binary strings of fixed length, but to hash into algebraic structures like groups, while keeping (some of) the properties of the hash function, like preimage resistance or collision resistance.
 
 
 Hash functions like this can be defined for various algebraic structures, but, in a sense, the most fundamental ones are hash functions that map into groups, because they can be easily extended to map into other structures like rings or fields.
 
-To give a more precise definition, let $\G$ be a group and $\{0,1\}^*$ the set of all finite, binary strings, then a \term{hash-to-group} function is a deterministic map
+To give a more precise definition, let $\G$ be a group and $\{0,1\}^*$ the set of all finite, binary strings, then a \term{hash-to-group} function is a deterministic map:
 \begin{equation}
 H : \{0,1\}^* \to \G
 \end{equation}
@@ -570,7 +570,7 @@ It can be shown that Pedersen’s  hash  function  is  collision-resistant under
 \{H_{\{g_1,\ldots,g_j\}}\;|\;g_1,\ldots,g_j\in \G\}
 \end{equation}
 
-From an implementation perspective, it is important to derive the set of generators $\{g_1,\ldots,g_k\}$ in such a way that they are as uniform and random as possible. In particular, any known discrete log relation between two generators, that is, any known $x\in \Z_n$ with $g_h = (g_i)^x$, must be avoided.
+From an implementation perspective, it is important to derive the set of generators $\{g_1,\ldots,g_k\}$ in such a way that they are as uniform and as random as possible. In particular, any known discrete log relation between two generators, that is, any known $x\in \Z_n$ with $g_h = (g_i)^x$, must be avoided.
 
 \begin{example} To compute an actual Pedersen’s  hash, consider the cyclic group $\Z^*_{5}$ from \examplename{} \ref{example:cyclic_group_F5*}. We know from \examplename{} \ref{example:factor_groupds_of_F*5} that the elements $2$ and $3$ are generators of  $\Z^*_{5}$, and it follows that the following map is a Pedersen's hash function:
 \begin{equation}
@@ -609,7 +609,7 @@ Consider the \capitalisewords{Pedersen hash} from \exercisename{} \ref{exercise:
 \end{exercise}
 
 %\citep{cryptoeprint:2016:492}
-\subsubsection{Pseudorandom Function Families in DDH-secure groups}
+\subsubsection{Pseudorandom Function Families in DDH-secure Groups}
 % https://fmouhart.epheme.re/Crypto-1617/TD08.pdf
 % Proper description in https://eprint.iacr.org/2016/492.pdf sec 3.3
 As noted in \ref{def:Pedersen_hash}, the family of Pederson's hash functions, parameterized by a set of generators $\{g_1,\ldots,g_j\}$ does not qualify as a family of pseudorandom functions, and should therefore not be instantiated as such. To see an example of a proper family of pseudorandom functions in groups where the decisional Diffie--Hellman assumption (see \secname \ref{def:DDH-secure}) is assumed to hold true, let $\G$ be a DDH-secure cyclic group of order $n$ with generator $g$, and let $\{a_0,a_1,\ldots,a_k\}\subset \Z_{n}^*$ be a uniform randomly generated set of numbers invertible in modular $n$ arithmetics. Then a family of pseudorandom functions, parameterized by the \uterm{seed} $\{a_0,a_1,\ldots,a_k\}$ is given as follows:
@@ -637,10 +637,10 @@ A \term{commutative ring with unit} $ (R, +, \cdot, 1) $ is a set $R$ with two m
 \item \hilight{Multiplicative neutral unit }: $1\cdot g=g$ for all $g\in R$.
 \item \hilight{Associativity}: For every $g_1,g_2,g_3\in\R$, the equation
 $g_1\cdot(g_2\cdot g_3) = (g_1\cdot g_2)\cdot g_3$ holds.
-\item \hilight{Distributivity}: For all $ g_1, g_2, g_3 \in R $, the distributive law
+\item \hilight{Distributivity}: For all $ g_1, g_2, g_3 \in\R $, the distributive law
 $ g_1 \cdot \left (g_2 + g_3 \right) = g_1 \cdot g_2 + g_1 \cdot g_3$ holds.
 \end{itemize}
-If $(R,+,\cdot,1)$ is a commutative ring with unit, and $R'\subset R$ is a subset of $R$ such that the restriction of addition and multiplication to $R'$ define a commutative ring with addition $+: R'\times R' \to R'$, multiplication $\cdot: R'\times R' \to R'$ and unit $1$ on $R'$, then $(R',+,\cdot,1)$ is called a \term{subring} of $(R,+,\cdot,1)$.
+If $(R,+,\cdot,1)$ is a commutative ring with unit, and $R'\subseteq R$ is a subset of $R$ such that the restriction of addition and multiplication to $R'$ define a commutative ring with addition $+: R'\times R' \to R'$, multiplication $\cdot: R'\times R' \to R'$ and unit $1$ on $R'$, then $(R',+,\cdot,1)$ is called a \term{subring} of $(R,+,\cdot,1)$.
 \end{definition}
 \begin{notation}Since we are exclusively concerned with commutative rings in this book, we often just call them rings, keeping the notation of commutativity implicit.
 A set $R$ with two maps, $+$ and $\cdot$, which satisfies all previously mentioned rules except for the commutativity law of multiplication, is called a non-commutative ring. 
@@ -896,7 +896,7 @@ H6 = list_plot(arr4, ymin=0,ymax=10000,color='black', legend_label='k2=16')
 \end{center}
 \end{example}
 
-\subsubsection{The ``try-and-increment'' method}\label{def:try_and_increment_hash}
+\subsubsection{The ``Try-and-increment'' Method}\label{def:try_and_increment_hash}
 
 A third method that can sometimes be found in implementations is the so-called \term{``try-and-increment'' method}. To understand this method, we define an integer $z\in\Z$ from any hash value $H(s)$ as we did in the previous methods:
 
@@ -978,7 +978,7 @@ Consider the ring of modular $5$ arithmetics $(\Z_5,+,\cdot)$ from \examplename{
 Consider the ring of modular $6$ arithmetics $(\Z_6,+,\cdot)$ from \examplename{} \ref{def_residue_ring_z_6}. Show that $(\Z_6,+,\cdot)$ is not a field.
 \end{exercise}
 
-\subsection{Prime fields}
+\subsection{Prime Fields}
 \label{prime_fields}
 As we have seen in many of the examples in previous sections, modular arithmetic behaves similarly to the ordinary arithmetics of integers  in many ways. This is due to the fact that remainder class sets $\Z_n$ are commutative rings with units (see \examplename{} \ref{def:ring_of_mod_n_arithmetics}).
 
@@ -1140,13 +1140,13 @@ Consider the prime field $\F_{13}$ from \exercisename{} \ref{prime_field_F13}. C
 %\end{definition}
 
 %\begin{remark}The algorithm (\ref{def: Tonelli-Shanks}) works in prime fields for any odd prime numbers. From a practical point of view, however, it is efficient only if the prime number is congruent to $ 1 $ modulo $ 4 $, since in the other case the formula from the proposition \ref{theorem: square_roots}, which can be calculated more quickly, can be used.\end{remark}
-\subsubsection{Hashing into prime fields}\label{hashing-prime-fields}
+\subsubsection{Hashing into Prime Fields}\label{hashing-prime-fields}
 An important problem in cryptography is the ability to hash to (various subsets) of elliptic curves. As we will see in \chaptname{} \ref{chap:elliptic_curves}, those curves are often defined over prime fields, and hashing to a curve might start with hashing to the prime field. It is therefore important to understand how to hash into prime fields.
 
 In \secname{} \ref{hash-to-modular-arithmetics}, we looked at a few methods of hashing into the modular arithmetic rings $\Z_n$ for arbitrary $n>1$. As prime fields are just special instances of those rings, all methods for hashing into $\Z_n$ functions can be used for hashing into prime fields, too.
 
 \begin{comment}
-\subsection{MiMC Hash functions} As we will see in XXX, 
+\subsection{MiMC Hash Functions} As we will see in XXX, 
 
 To define a MiMC hash function, let $\F_p$ be a prime field with prime modulus $p\in\Prim$, let $n$ be the smallest natural number such that  $gcd(n, p-1) = 1$. Let $r$ be the smallest integer greater than or equal to $\frac{log(p)}{log_2(3)}$ and let $C=\{c_i\in \F_p \;|\; 0\leq i \leq r\}$ be a set of randomly generated field elements. The definition of the MiMC hash function then starts with an invertible map
 \begin{equation}
@@ -1303,7 +1303,7 @@ y^2 = x^3 + 4
 \end{exercise}
 
 \begin{comment}
-\subsection{Hashing into extension fields} On page \pageref{hashing-prime-fields},\sme{check reference} we have seen how to hash into prime fields. As elements of extension fields can be seen as polynomials over prime fields, hashing into extension fields is therefore possible if every coefficient of the polynomial is hashed independently.
+\subsection{Hashing into Extension Fields} On page \pageref{hashing-prime-fields},\sme{check reference} we have seen how to hash into prime fields. As elements of extension fields can be seen as polynomials over prime fields, hashing into extension fields is therefore possible if every coefficient of the polynomial is hashed independently.
 \end{comment}
 \section{Projective Planes}\label{sec:planes}
 Projective planes are particular geometric constructs defined over a given field. In a sense, projective planes extend the concept of the ordinary Euclidean plane by including ``points at infinity.''\footnote{A detailed explanation of the ideas that lead to the definition of projective planes can be found, for example, in \chaptname{} 2 of \cite{ellis-1992} or in appendix A of \cite{silverman-1994}.}

--- a/chapters/arithmetics-moonmath.tex
+++ b/chapters/arithmetics-moonmath.tex
@@ -4,7 +4,7 @@
 
 The goal of this chapter is to bring a reader with only basic school-level algebra up to speed in arithmetic. We start with a brief recapitulation of basic integer arithmetics, discussing long division, the greatest common divisor and \concept{Euclidean division}. After that, we introduce modular arithmetic as \hilight{the most important} skill to compute our pen-and-paper examples. We then introduce polynomials, compute their analogs to integer arithmetics and introduce the important concept of \concept{Lagrange interpolation}.
 
-\section{Integer arithmetic}
+\section{Integer Arithmetic}
 \label{integer_arithmetic}
 In a sense, integer arithmetic is at the heart of large parts of modern cryptography. Fortunately, most readers will probably remember integer arithmetic from school. It is, however, important that you can confidently apply those concepts to understand and execute computations in the many pen-and-paper examples that form an integral part of the MoonMath Manual. We will therefore recapitulate basic arithmetic concepts to refresh your memory and fill any knowledge gaps.
 
@@ -12,7 +12,7 @@ Even though the terms and concepts in this chapter might not appear in the liter
 
 Many of the ideas presented in this chapter are taught in basic mathematical education in most schools around the globe. Much of the ideas presented in this section can be found in \cite{wu-1}. An approach more oriented towards computer science can be found in \cite{mignotte-1992}.
 
-\subsection{Integers, natural numbers and rational numbers}
+\subsection{Integers, Natural Numbers and Rational Numbers}
 
 Integers are also known as \term{whole numbers}, that is, numbers that can be written without fractional parts. Examples of numbers that are \hilight{not} integers are $\frac{2}{3}$, $1.2$ and $-1280.006$.\footnote{Whole numbers, along with their basic laws of operations, are introduced for example in chapters 1 – 6 of \cite{wu-1}.}
 
@@ -113,7 +113,7 @@ Compute the set of all solutions $x$ under the following assumptions:
 \end{enumerate}
 \end{exercise}
 
-\subsection{\concept{Euclidean division}}
+\subsection{\concept{Euclidean Division}}
 \label{Euclidean_division}
 As we know from high school mathematics, integers can be added, subtracted and multiplied, and the result of these operations is guaranteed to always be an integer as well.
 On the contrary, division (in the commonly understood sense) is not defined for integers, as, for example, $7$ divided by $3$ will not result in an integer. However, it is always possible to divide any two integers if we consider \term{division with a remainder}. For example, $7$ divided by $3$ is equal to $2$ with a remainder of $1$, since $7 = 2\cdot 3 + 1$.
@@ -363,7 +363,7 @@ n = & \sum_{i=0}^4 j_i\cdot 16^{i} \\
 \begin{exercise}Consider the \term{octal} positional system, which represents integers with 8 digits, usually written as $\{0,1,2,3,4,5,6,7\}$. Numbers in this system are characterized by the prefix $0o$. Write the numbers $0o1354$ and $0o777$ into their decimal representation.
 \end{exercise}
 
-\section{Modular arithmetic}
+\section{Modular Arithmetic}
 \label{modular_arithmetic}
 \term{Modular arithmetic} is a system of integer arithmetic where numbers ``wrap around'' when reaching a certain value, much like calculations on a clock wrap around whenever the value exceeds the number $12$. For example, if the clock shows that it is $11$ o'clock, then $20$ hours later it will be $7$ o'clock, not $31$ o'clock. The number $31$ has no meaning on a normal clock that shows hours.
 
@@ -473,7 +473,7 @@ sage: (ZZ(7)* (ZZ(2)*ZZ(4) + ZZ(21)) + ZZ(11))  % ZZ(6) == (ZZ(4) - ZZ(102))  % 
 sage: (ZZ(7)* (ZZ(2)*ZZ(76) + ZZ(21)) + ZZ(11))  % ZZ(6) == (ZZ(76) - ZZ(102))  % ZZ(6)
 \end{sagecommandline}
 \end{example}
-If you had not been familiar with modular arithmetic until now and who might be discouraged by how complicated modular arithmetic seems at this point, you should keep two things in mind. First, computing congruences in modular arithmetic is not really more complicated than computations in more familiar number systems (e.g. rational numbers), it is just a matter of getting used to it. Second, once we introduce the idea of remainder class representations in \ref{def:remainder_class_representation}, computations become conceptually cleaner and easier to handle.
+If you are not yet familiar with modular arithmetic and feel discouraged by how complicated modular arithmetic seems at this point, you should keep two things in mind. First, computing congruences in modular arithmetic is not really more complicated than computations in more familiar number systems (e.g. rational numbers), it's just a matter of getting used to it. Second, once we introduce the idea of remainder class representations in \ref{def:remainder_class_representation}, computations become conceptually cleaner and easier to handle.
 \begin{exercise}
 \label{exercise_congruence_in_F13}
 Consider the modulus $13$ and find all solutions $x\in \Z$ to the following congruence: $$\kongru{5x+4}{28+2x}{13}$$
@@ -789,7 +789,7 @@ Find the set of all solutions to the congruence $\kongru{17(2x+5)-4}{2x+4}{5}$. 
 \begin{exercise}
 Find the set of all solutions to the congruence $\kongru{17(2x+5)-4}{2x+4}{6}$. Then project the congruence into $\Z_6$ and try to solve the resulting equation in $\Z_6$.
 \end{exercise}
-\section{Polynomial arithmetic}
+\section{Polynomial Arithmetic}
 \label{sec:polynomial_arithmetics}
 A polynomial is an expression consisting of variables (also called indeterminates) and coefficients that involves only the operations of addition, subtraction and multiplication. All coefficients of a polynomial must have the same type, e.g. they must all be integers or they must all be rational numbers, etc.\footnote{An introduction to the theory of polynomials can be found, for example, in \chaptname{} 3 of \cite{mignotte-1992} and a detailed description of many algorithms used in computations on polynomials are given in \chaptname{} 3 of \cite{cohen-2010}.}
 
@@ -928,7 +928,7 @@ sage: p1(Z6(2)) == Z6(5)
 \begin{exercise}
 Compare both expansions of $P_7$ from $\Z[x]$ in \examplename{} \ref{example:integer_polynomials} and from  from $\Z_6[x]$ in \examplename{} \ref{example:integer_mod_6_polynomials} , and consider the definition of $\Z_6$ as given in \examplename{} \ref{def_residue_ring_z_6}. Can you see how the definition of $P_7$ over $\Z$ projects to the definition over $\Z_6$ if you consider the residue classes of $\Z_6$?\sme{the task could be defined more clearly}
 \end{exercise}
-\subsection{Polynomial arithmetic}\sme{this is the same as the section title}
+\subsection{Polynomial Arithmetic}\sme{this is the same as the section title}
 Polynomials behave like integers in many ways. In particular, they can be added, subtracted and multiplied. In addition, they have their own notion of \concept{Euclidean division}. Informally speaking, we can add two polynomials  by simply adding the coefficients of the same index, and we can multiply them by applying the distributive property, that is, by multiplying every term of the left factor with every term of the right factor and adding the results together.
 
 To be more precise, let $ \sum _{n = 0} ^{m_1}{a} _{n}{x} ^{n} $ and
@@ -988,7 +988,7 @@ sage: P*Q == Z6x(5*x^5 +4*x^4 +4*x^3+3*x^2+4*x +4)
 \begin{exercise}
 Compare the sum $P+Q$ and the product $P\cdot Q$ from the previous two examples \ref{example:integer_polynomial_arithmetic_1} and \ref{example:integer_mod_6_polynomial_arithmetic_1}, and consider the definition of $\Z_6$ as given in \examplename{} \ref{def_residue_ring_z_6}. How can we derive the computations in $\Z_6[x]$ from the computations in $\Z[x]$?
 \end{exercise}
-\subsection{\concept{Euclidean division} with polynomials}
+\subsection{\concept{Euclidean Division} with Polynomials}
 The arithmetic of polynomials shares a lot of properties with the arithmetic of integers. As a consequence, the concept of \concept{Euclidean division} and the algorithm of long division is also defined for polynomials. Recalling the \concept{Euclidean division} of integers \ref{Euclidean_division}, we know that, given two integers $a$ and $b\neq 0$, there is always another integer $m$ and a natural number $r$ with $r<|b|$ such that $a = m\cdot b +r$ holds.
 
 We can generalize this to polynomials whenever the leading coefficient of the dividend polynomial has a notion of multiplicative inverse. In fact, given two polynomials $A$ and $B\neq 0$ from $R[x]$ such that $Lc(B)^{-1}$ exists in $R$, there exist two polynomials $Q$ (the quotient) and $P$ (the remainder), such that the following equation holds and $deg(P) < deg(B)$:
@@ -1121,11 +1121,11 @@ Show that if the sum of the multiplicity of all roots of a polynomial $P\in R[x]
 \begin{exercise}
 Consider the polynomial $P=x^7 + 3 x^6 + 3 x^5 + x^4 - x^3 - 3 x^2 - 3 x - 1\in \Z_6[x]$. Compute the set of all roots of $R_0(P)$ and then compute the prime factorization of $P$.
 \end{exercise}
-\subsection{\concept{Lagrange interpolation}}
+\subsection{\concept{Lagrange Interpolation}}
 One particularly useful property of polynomials is that a polynomial of degree $m$ is completely determined on $m+1$ evaluation points, which implies that we can uniquely derive a polynomial of degree $m$ from a set $S$:
 \begin{equation}
 \label{def_lagrange_interpolation_set}
-S= \{(x_0,y_0), (x_1,y_1),\ldots,(x_m,y_m)\;|\; x_i\neq x_j\text{ for all indices i and j}\}
+S= \{(x_0,y_0), (x_1,y_1),\ldots,(x_m,y_m)\;|\; x_i\neq x_j\text{ for all indices $ i $ and $ j $}\}
 \end{equation}
 Polynomials therefore have the property that $m+1$ pairs of points $(x_i,y_i)$ for $x_i\neq x_j$ are enough to determine the set of pairs $(x,P(x))$ for all $x\in R$. This ``few too many'' property of polynomials is widely used, including in SNARKs. Therefore, we need to understand the method to actually compute a polynomial from a set of points.
 
@@ -1135,7 +1135,7 @@ If the coefficients of the polynomial we want to find have a notion of multiplic
 \label{alg_lagrange_interplation}
 \begin{algorithmic}[0]
 \Require $R$ must have multiplicative inverses
-\Require $S= \{(x_0,y_0), (x_1,y_1),\ldots,(x_m,y_m)\;|\; x_i,y_i\in R, x_i\neq x_j\text{ for all indices i and j}\}$
+\Require $S= \{(x_0,y_0), (x_1,y_1),\ldots,(x_m,y_m)\;|\; x_i,y_i\in R, x_i\neq x_j\text{ for all indices $ i $ and $ j $}\}$
 \Procedure{Lagrange-Interpolation}{$S$}
 \For{$j \in (0\ldots m)$}
 \State  $l_j(x) \gets \Pi_{i=0;i\neq j}^{m}\frac{x-x_i}{x_j-x_i} = \frac{(x-x_0)}{(x_j-x_0)} \cdots \frac{(x-x_{j-1})}{(x_j-x_{j - 1})} \frac{(x-x_{j+1})}{(x_j-x_{j+1})} \cdots \frac{(x-x_m)}{(x_j-x_m)}$

--- a/chapters/circuit-compilers-moonmath.tex
+++ b/chapters/circuit-compilers-moonmath.tex
@@ -249,7 +249,7 @@ snarkjs r1cs info circuit.r1cs
 \end{lstlisting}
 \end{example}
 
-\section{Common Programing concepts}
+\section{Common Programing Concepts}
 In this section, we cover concepts that appear in almost every programming language, and see how they can be implemented in circuit compilers. 
 \subsection{Primitive Types} 
 % https://zeroknowledge.fm/172-2/ reference for all the languages
@@ -257,7 +257,7 @@ Primitive data types like booleans, (unsigned) integers, or strings are the most
 
 In this section, we look at some common ways to achieve this. After a review of the atomic type for the base field where the circuit is defined on, we start with an implementation of the boolean type and its associated boolean algebra as circuits. After that, we define unsigned integers based on the boolean type, and leave the implementation of signed integers as an exercise to the reader. 
 
-\subsubsection{The base-field type} 
+\subsubsection{The Base-field Type} 
 \label{def:base_field_type}
 Since both algebraic circuits and their associated Rank-1 Constraint Systems are defined over a finite field, elements from that field are the atomic informational units in those models. In this sense, field elements $x\in \F$ are for algebraic circuits what bits are for computers. 
 
@@ -719,7 +719,7 @@ We then proceed inductively choosing circuits for the outer most operators, whic
 \end{comment}
 \sme{Is the comment group hidden on purpose?}
 
-\subsubsection{The boolean Type} 
+\subsubsection{The Boolean Type} 
 % implementations can be found here: https://github.com/filecoin-project/zexe/tree/master/snark-gadgets/src/bits
 Booleans are a classical primitive type, implemented by virtually every higher programing language. It is therefore important to implement booleans in circuits. One of the most common ways to do this is by interpreting the additive and multiplicative neutral element $\{0,1\}\subset \F$ as the two boolean values such that $0$ represents $false$ and $1$ represents $true$. Boolean operators like $and$, $or$, or $xor$ are then expressible as algebraic circuits over $\F$. 
 
@@ -2146,7 +2146,7 @@ To see how the associated circuit works, we want to enforce the binary represent
 \end{example}
 \subsection{Cryptographic Primitives}
 In applications, it is often required to do cryptography in a circuit. To do this, basic cryptographic primitives like hash functions or elliptic curve cryptography needs to be implemented as circuits. In this section, we give a few basic examples of how to implement such primitives. 
-\subsubsection{Twisted Edwards curves} Implementing elliptic curve cryptography in circuits means to implement the defining curve equations as well as the algebraic operations, like the group law or the scalar multiplication as circuits. To do this efficiently, the curve must be defined over the same base field as the field that is used in the circuit. 
+\subsubsection{Twisted Edwards Curves} Implementing elliptic curve cryptography in circuits means to implement the defining curve equations as well as the algebraic operations, like the group law or the scalar multiplication as circuits. To do this efficiently, the curve must be defined over the same base field as the field that is used in the circuit. 
 
 For efficiency reasons, it is advantageous to choose an elliptic curve such that that all required constraints and operations can be implemented with as few gates as possible. Twisted Edwards curves are particularly useful for that matter, since their group law is particularly simple and the same calculation can be used for all curve points including the point at infinity. This simplifies the circuit a lot.
 % implementations https://github.com/iden3/circomlib/blob/master/circuits/babyjub.circom

--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -7,7 +7,7 @@ A special class of elliptic curves are so-called pairing-friendly curves, which 
 
 In this chapter, we introduce elliptic curves as they are used in pairing-based approaches to the construction of SNARKs. The elliptic curves we consider are all defined over prime fields or prime field extensions, meaning that we rely heavily on the concepts and notations from \chaptname{} \ref{chap:algebra}. 
 
-\section{\concept{short Weierstrass} Curves}
+\section{\concept{Short Weierstrass} Curves}
 \label{sec:short_weierstrass_curve}
 In this section, we introduce \term{\concept{short Weierstrass} curves}, which are the most general types of curves over finite fields of characteristics greater than $3$ (see \chaptname{} \ref{def:characteristic}), and start with their so-called \term{affine representation}.\sme{do we still need the explanation of projective planes from the previous chapter? or can they be moved to this one?}\footnote{Introducing elliptic curves in their affine representation is probably not the most common and conceptually cleanest way, but we believe that such an introduction makes elliptic curves more understandable to beginners, since an elliptic curve in the affine representation is just a set of pairs of numbers, so it is more accessible to readers unfamiliar with projective coordinates. However, the affine representation has the disadvantage that a special ``point at infinity'' that is not a point on the curve, is necessary to describe the curve's group structure.}
 
@@ -15,7 +15,7 @@ We then introduce the elliptic curve group law, and describe elliptic curve scal
 
 We finish this section with an explicit equivalence that transforms the affine representations into projective representations and vice versa.
 
-\subsection{Affine \concept{short Weierstrass} form} Probably the least abstract and most straight-forward way to introduce elliptic curves for non-mathematicians and beginners is the so-called \term{affine representation} of a \term{\concept{short Weierstrass} curve}. To see what this is, let $\F$ be a finite field of characteristic $q$ with $q>3$, and let $a,b\in \F$ be two field elements such that the so-called \term{discriminant} $4a^3+ 27b^2$ is not equal to zero. Then a \term{\concept{short Weierstrass} elliptic curve} $E_{a,b}(\F)$ over $\F$ in its affine representation is the set of all pairs of field elements $(x,y)\in \F\times \F$ that satisfy the \concept{short Weierstrass} cubic equation $y^2=x^3+a\cdot x+b$, together with a distinguished symbol $\Oinf$, called the \term{point at infinity}:
+\subsection{Affine \concept{Short Weierstrass} Form} Probably the least abstract and most straight-forward way to introduce elliptic curves for non-mathematicians and beginners is the so-called \term{affine representation} of a \term{\concept{short Weierstrass} curve}. To see what this is, let $\F$ be a finite field of characteristic $q$ with $q>3$, and let $a,b\in \F$ be two field elements such that the so-called \term{discriminant} $4a^3+ 27b^2$ is not equal to zero. Then a \term{\concept{short Weierstrass} elliptic curve} $E_{a,b}(\F)$ over $\F$ in its affine representation is the set of all pairs of field elements $(x,y)\in \F\times \F$ that satisfy the \concept{short Weierstrass} cubic equation $y^2=x^3+a\cdot x+b$, together with a distinguished symbol $\Oinf$, called the \term{point at infinity}:
 
 \begin{equation}
 \label{def_short_weierstrass_curve}
@@ -178,7 +178,7 @@ sage: r.nbits()
 \begin{exercise}
 Look up the definition of curve \curvename{BLS12-381}, implement it in Sage, and compute the number of all curve points.
 \end{exercise}
-\subsubsection{Isomorphic affine \concept{short Weierstrass} curves}
+\subsubsection{Isomorphic Affine \concept{Short Weierstrass} Curves}
 \label{sec:isomorphic_curves} As explained previously in this chapter, elliptic curves are defined by pairs of parameters $(a, b)\in \F\times \F$ for some field $\F$. An important question in classifying elliptic curves is to decide which pairs of parameters $(a,b)$ and $(a',b')$ instantiate equivalent curves in the sense that there is a 1:1 correspondence between the set of curve points.
 
 To be more precise, let $\F$ be a field, and let $(a,b)$ and $(a',b')$ be two pairs of parameters such that there is an invertible field element $c\in \F^*$ such that $a' = a\cdot c^4$ and $b' = b\cdot c^6$ hold. Then the elliptic curves $E_{a,b}(\F)$ and $E_{a',b'}(\F)$ are \term{isomorphic}, and there is a map that maps the curve points of $E_{a,b}(\F)$ onto the curve points of $E_{a',b'}(\F)$:
@@ -216,7 +216,7 @@ E_{7,5}(\F_{13}) = \{ (x,y)\in \F_{13}\times \F_{13}\;|\; y^2 = x^3 + 7x +5\}
 Show that $TJJ\_13$ and $E_{7,5}(\F_{13})$ are isomorphic. Then compute the set of all points from $E_{7,5}(\F_{13})$, construct $I$ and map all points of $TJJ\_13$ onto $E_{7,5}(\F_{13})$.
 \end{exercise}
 
-\subsubsection{Affine compressed representation}
+\subsubsection{Affine Compressed Representation}
 \label{sec:affine_point_compression}
 As we have seen in \examplename{} \ref{secp256k1}, cryptographically secure elliptic curves are defined over large prime fields, where elements of those fields typically need more than $255$ bits of storage on a computer. Since elliptic curve points consist of pairs of those field elements, they need double that amount of storage.
 
@@ -259,7 +259,7 @@ sage: ZZ(PCOMPRESSED[0]).nbits()+ZZ(PCOMPRESSED[1]).nbits()
 \end{example}\sme{add explanation of how this shows what we claim}
 \end{comment}
 
-\subsection{\concept{Affine group law}}
+\subsection{\concept{Affine Group Law}}
 \label{sec:affine_group_law}
 %group law
 % http://wwwmayr.informatik.tu-muenchen.de/konferenzen/Jass07/courses/1/Lukyanenko/Lukyanenk_Paper.pdf
@@ -410,7 +410,7 @@ Consider the commutative group $(\mathit{TJJ\_13},\oplus)$ of the \curvename{Tin
 \end{enumerate}
 \end{exercise}
 
-\subsubsection{Scalar multiplication}
+\subsubsection{Scalar Multiplication}
 As we have seen in the previous section, elliptic curves $E(\F)$ have the structure of a commutative group associated to them. It can be shown that this group is finite and cyclic whenever the underlying field $\F$ is finite. As we know from \eqref{scalarmultiplication}, this implies that there is a notation of scalar multiplication associated to any elliptic curve over finite fields.
 
 To understand this scalar multiplication, recall from \defname{} \ref{cyclic-groups} that every finite cyclic group of order $n$ has a generator $g$ and an associated exponential map $g^{(\cdot)}: \Z_n \to \G$, where $g^x$ is the $x$-fold product of $g$ with itself.  
@@ -531,7 +531,7 @@ $\{[1](0,1), [2](0,1),\ldots,[8](0,1,[9](0,1)\}$ using the tangent rule only.
 \end{exercise}
 \begin{exercise} Consider \examplename{} \ref{ex:TJJ13-cofactor-clearing} and compute the scalar multiplications $[10](5,11)$ as well as $[10](9,4)$ and $[4](9,4)$ with pen and paper using the algorithm from exercise \ref{alg_double-and-add}.
 \end{exercise}
-\subsection{Projective \concept{short Weierstrass} form}
+\subsection{Projective \concept{Short Weierstrass} Form}
 % https://www.cosic.esat.kuleuven.be/bcrypt/lecture%20slides/wouter.pdf
 As we have seen in the previous section, describing elliptic curves as pairs of points that satisfy a certain equation is relatively straight-forward. However, in order to define a group structure on the set of points, we had to add a special point at infinity to act as the neutral element. 
 
@@ -606,7 +606,7 @@ Consider \examplename{} \ref{ex:E1F5-projective} and compute the set \eqref{E1F5
 Compute the projective representation of the \curvename{Tiny-jubjub} curve (\examplename{} \ref{TJJ13}) and the logarithmic order of its large prime-order subgroup with respect to the generator $[7:11:1]$ in projective coordinates.
 \end{exercise}
 
-\subsubsection{Projective Group law}
+\subsubsection{Projective Group Law}
 \label{sec:projective_group_law}
 As we saw in section \ref{sec:affine_group_law}, one of the key properties of an elliptic curve is that it comes with a definition of a group law on the set of its points, described geometrically by the chord-and-tangent rule (\defname{} \ref{def:chord-and-tangent}). This rule was fairly intuitive, with the exception of the distinguished point at infinity, which appeared whenever the chord or the tangent did not have a third intersection point with the curve.
 
@@ -816,7 +816,7 @@ Consider the elliptic curve $E_{1,1}(\F_5)$ from \examplename{} \ref{E1F5} and s
 Consider the elliptic curve \curvename{secp256k1} from \examplename{} \ref{secp256k1} and show that \curvename{secp256k1} is not a Montgomery curve.
 \end{exercise}
 
-\subsection{Affine Montgomery coordinate transformation} Comparing the Montgomery representation in \eqref{eq:TJJ13-montgomery-representation} with the \concept{short Weierstrass} representation of the same curve in \eqref{eq:TJJ13-weierstrass}, we see that there is a 1:1 correspondence between the curve points in these two examples. This is no accident. In fact, if $M_{A,B}$ is a Montgomery curve, and $E_{a,b}$ a \concept{short Weierstrass} curve with $a = \frac{3-A^2}{3B^2}$ and $b= \frac{2A^2 -9A}{27B^3}$, then the following function maps all points in Montgomery representation onto the points in \concept{short Weierstrass} representation:
+\subsection{Affine Montgomery Coordinate Transformation} Comparing the Montgomery representation in \eqref{eq:TJJ13-montgomery-representation} with the \concept{short Weierstrass} representation of the same curve in \eqref{eq:TJJ13-weierstrass}, we see that there is a 1:1 correspondence between the curve points in these two examples. This is no accident. In fact, if $M_{A,B}$ is a Montgomery curve, and $E_{a,b}$ a \concept{short Weierstrass} curve with $a = \frac{3-A^2}{3B^2}$ and $b= \frac{2A^2 -9A}{27B^3}$, then the following function maps all points in Montgomery representation onto the points in \concept{short Weierstrass} representation:
 \begin{equation}
 I: M_{A,B} \to E_{a,b}\; : \; (x,y) \mapsto \left(\frac{3x + A}{3B}, \frac{y}{B}\right)
 \end{equation}
@@ -869,7 +869,7 @@ sage: MTJJ == IINV_WTJJ
 \end{sagecommandline}
 \end{example}
 
-\subsection{Montgomery group law} We have seen that Montgomery curves are special cases of \concept{short Weierstrass} curves. As such, they have a group structure defined on the set of their points, which can also be derived from the chord-and-tangent rule. In accordance with \concept{short Weierstrass} curves, it can be shown that the identity $x_1=x_2$ implies $y_2=\pm y_1$, meaning that the following rules are a complete description of the elliptic curve group law:
+\subsection{Montgomery Group Law} We have seen that Montgomery curves are special cases of \concept{short Weierstrass} curves. As such, they have a group structure defined on the set of their points, which can also be derived from the chord-and-tangent rule. In accordance with \concept{short Weierstrass} curves, it can be shown that the identity $x_1=x_2$ implies $y_2=\pm y_1$, meaning that the following rules are a complete description of the elliptic curve group law:
 
 \begin{definition}[\deftitle{Montgomery group law}]\label{def:montgomery-group-law}
 \defvsep{}
@@ -993,7 +993,7 @@ sage: L_ETJJ = []
 sage: ETJJ = Set(L_ETJJ)
 \end{sagecommandline}
 \end{example}
-\subsection{Twisted Edwards group law}
+\subsection{Twisted Edwards Group Law}
 \label{sec:twisted_ed_group_law} As we have seen, \concept{twisted Edwards} curves are equivalent to Montgomery curves, and, as such, they also have a group law. However, in contrast to Montgomery and \concept{short Weierstrass} curves, the group law of SNARK-friendly \concept{twisted Edwards} curves can be described by a single computation that works in all cases, even if we add the neutral element, the inverse, or if we have to double a point. 
 
 To see what the \concept{twisted Edwards} group law looks like, let $(x_1, y_1)$, $(x_2, y_2)$ be two points on an Edwards curve $E(\F)$. The sum of those points is then given by the following equation:
@@ -1170,7 +1170,7 @@ sage: k
 
 
 
-\subsubsection{Elliptic Curves over extension fields}
+\subsubsection{Elliptic Curves over Extension Fields}
 \label{sec:curve-extensions}
 \sme{TODO:Rewrite intro together with Sven} Suppose that $p$ is a prime number, and $\F_p$ its associated prime field. We know from equation \eqref{eq:prime-extension-field} that the fields $\F_{p^m}$ are extensions of $\F_p$ in the sense that $\F_{p}$ is a subfield of $\F_{p^m}$. This implies that we can extend the affine plane that an elliptic curve is defined on by changing the base field to any extension field. To be more precise, let 
 $E(\F)=\{ (x,y)\in \F \times \F \;|\; y^2 = x^3 +a\cdot x +b \}$ be an affine \concept{short Weierstrass} curve, with parameters $a$ and $b$ taken from $\F$. If $\F'$ is an extension field of $\F$, then we extend the domain of the curve by defining $E(\F')$ as follows:
@@ -1216,7 +1216,7 @@ As we can see, the set of points from the elliptic curve $E_{1,1}(\F_5)$ is a su
 \label{exercise:BN128-extension}
 Consider the \curvename{alt\_bn128} curve and its associated base field $\F_p$ from \examplename{} \ref{BN128}. As we know from example \ref{ex:embedding_degre_BN128} this curve has an embedding degree of $12$. Use Sage to find an irreducible polynomial $P\in \F_p[t]$ and write a sage program to implement the finite field extension $\F_{p^{12}}$ and to implement the curve extension $alt\_bn128(\F_{p^{12}})$ and compute the number of curve points.
 \end{exercise}
-\subsection{Full torsion groups}
+\subsection{Full Torsion Groups}
 \label{sec:full-torsion} As we will see in what follows, cryptographically interesting pairings are defined on so-called torsion subgroups of elliptic curves. To define \term{torsion groups} of an elliptic curve, let $\F$ be a finite field, $E(\F)$ an elliptic curve of order $n$ and $r$ a factor of $n$. Then the \term{$r$-torsion group} of the elliptic curve $E(\F)$ is defined as the set
 \begin{equation}
 \label{def:torsion_group}
@@ -1319,7 +1319,7 @@ This means that the embedding degree is very large, which implies that the field
  Consider the curve \curvename{alt\_bn128} from \examplename{} \ref{BN128} and its curve extension from exercise \ref{exercise:BN128-extension}. Write a Sage program that computes a generator from the curves full torsion group.
 \end{exercise}
 
-\subsection{Pairing groups}
+\subsection{Pairing Groups}
 \label{sec:pairing_groups}
  As we have stated above, any full $r$-torsion group contains $r+1$ cyclic subgroups, two of which are of particular interest in pairing-based elliptic curve cryptography. To characterize these groups, we need to consider the so-called \term{Frobenius endomorphism} of an elliptic curve $E(\F)$ over some finite field $\F$ of characteristic $p$:
 \begin{equation}\label{eq:frobenius-enomorphism}
@@ -1420,7 +1420,7 @@ Consider the small prime factor $2$ of the \curvename{Tiny-jubjub} curve. Comput
 \end{exercise}
 
 
-\subsection{The Weil pairing}
+\subsection{The Weil Pairing}
 \label{sec:weil-pairing} Recall the definition of a non-degenerate group pairing from \ref{pairing-map}. In this part, we consider a pairing function defined on
 the subgroups $\G_1[r]$ and $\G_2[r]$ of the full $r$-torsion $E[r]$ of a \concept{short Weierstrass} elliptic curve. To be more precise, let $E(\F_p)$ be an elliptic curve of embedding degree $k$ such that $r$ is a prime factor of its order. Then the \term{Weil pairing} is defined as the following bilinear, non-degenerate map:
 
@@ -1511,7 +1511,7 @@ Consider the curve \curvename{alt\_bn128} from \examplename{} \ref{BN128} and th
 
 As we have seen in section \ref{sec:hashing-to-groups}, some general methods are known for hashing into finite cyclic groups and since elliptic curves over finite fields are finite and cyclic groups, those methods can be utilized in this case, too. However, in what follows we want to describe some methods specific to elliptic curves that are frequently used in real-world applications. 
 
-\subsection{Try-and-increment hash functions}
+\subsection{Try-and-increment Hash Functions}
 One of the most straight-forward ways of hashing onto an elliptic curve point in a secure way is to use a cryptographic hash function together with one of the hashing into modular arithmetics methods as described in section \ref{hash-to-modular-arithmetics}.
 
 Both constructions can be combined in such a way that the image provides an element of the base field of the elliptic curve together with a single auxiliary bit. The base field element can then be interpreted as the $x$-coordinate of a potential curve point, and the auxiliary bit can be used to determine one of the two possible $y$ coordinates of that curve point as explained in \ref{sec:affine_point_compression}.
@@ -1600,7 +1600,7 @@ Use our definition of the $try\_hash$ algorithm to implement a hash function $H_
 \begin{exercise}
 Implement a cryptographic hash function $H_{secp256k1} : \{0,1\}^*\to secp256k1$ that maps binary strings of arbitrary length onto the elliptic curve \curvename{secp256k1}. 
 \end{exercise}
-\section{Constructing elliptic curves} Cryptographically secure elliptic curves like \curvename{secp256k1} \ref{secp256k1} have been known for quite some time. Given the latest advancements in cryptography, however, it is often necessary to design and instantiate elliptic curves from scratch that satisfy certain very specific properties. 
+\section{Constructing Elliptic Curves} Cryptographically secure elliptic curves like \curvename{secp256k1} \ref{secp256k1} have been known for quite some time. Given the latest advancements in cryptography, however, it is often necessary to design and instantiate elliptic curves from scratch that satisfy certain very specific properties. 
 
 For example, in the context of SNARK development, it became necessary to design elliptic curves that can be efficiently implemented inside of a so-called \uterm{algebraic circuit} in order to enable primitives like elliptic curve \uterm{signature schemes} in a zero-knowledge proof. Such a curve is given by the Baby-jubjub curve as defined in \cite{whitehat-21}, and we have paralleled its definition by introducing the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13}. As we have seen, those curves are instances of so-called \concept{twisted Edwards} curves, and as such have easy to implement addition laws that work without branching. However, we introduced the \curvename{Tiny-jubjub} curve out of thin air, as we just gave the curve parameters without explaining how we came up with them.
 
@@ -1704,7 +1704,7 @@ sage: j == F(0)
 \label{exercise:BN128-j-inv}
 Consider the curve \curvename{alt\_bn128} from \examplename{} \ref{BN128}. Write a Sage program that computes the $j$-invariant for \curvename{alt\_bn128}.
 \end{exercise}
-\subsection{The \concept{complex multiplication method}}\label{complex-multiplication-method}
+\subsection{The \concept{Complex Multiplication Method}}\label{complex-multiplication-method}
 As we have seen in the previous sections, elliptic curves have various defining properties, like their order, their prime factors, the embedding degree, or the order of the base field. The \term{\concept{complex multiplication method}} (CM) provides a practical way of constructing elliptic curves with pre-defined restrictions on the order of the curve and the base field.\footnote{A detailed explanation of the complex multiplication
 method and its derivation can be found, for example, in \cite{grech-2012}.}
 
@@ -2027,7 +2027,7 @@ y^2 = x^3 + 7
 $,
 which we might call \curvename{secp256k1}. As we have just seen, the \concept{complex multiplication method} is powerful enough to derive cryptographically secure curves like \curvename{secp256k1} from scratch.
 \end{example}
-%\section{twists}
+%\section{Twists}
 %I think this has to wait for Volume 2, due to timing constraints...
 \begin{exercise}
 \label{ex:Low_order_Hilbert_polys} Show that the Hilbert class polynomials for the CM-discriminants $D=-3$ and $D=-4$ are given by  $H_{-3,q}(x)=x$ and $H_{-4,q}= x-(\Zmod{1728}{q})$.
@@ -2042,7 +2042,7 @@ Use the complex multiplication method to compute all isomorphism classes of all 
 \label{exercise:BN128-cm-method}
 Consider the prime modulus $p$ of curve \curvename{alt\_bn128} from \examplename{} \ref{BN128} and its trace $t$ from exercise \ref{exercise:BN128-cm-method}. Use the complex multiplication method to synthesize an elliptic curve over $F_p$ that is isomorphic to \curvename{alt\_bn128} and compute an explicit isomorphism between these two curves.
 \end{exercise}
-\subsection{The $BLS6\_6$ pen-and-paper curve}\label{BLS6}
+\subsection{The $BLS6\_6$ Pen-and-paper Curve}\label{BLS6}
 
 % https://arxiv.org/pdf/1207.6983.pdf
 % construction 6.6 in https://eprint.iacr.org/2006/372.pdf
@@ -2151,7 +2151,7 @@ BLS63p = BLS63.plot()
 
 As we can see, our curve has some desirable properties: it does not contain self-inverse points, that is, points with $y=0$. It follows that the addition law can be optimized, since the branch for those cases can be eliminated. 
 
-\subsubsection{The large prime order subgroup}
+\subsubsection{The Large Prime Order Subgroup}
 Summarizing the previous procedure, we have used the method of Barreto, Lynn and Scott\sme{add reference} to construct a pairing-friendly elliptic curve of embedding degree $6$. However, in order to do elliptic curve cryptography on this curve, note that, since the order of $BLS6\_6$ is $39$, its group is not of prime order. We therefore have to find a suitable subgroup as our main target. Since $39=13\cdot 3$, we know that the curve must contain a ``large'' prime-order group of size $13$ called $BLS6\_6(\F_{43})[13]$ according to definition \ref{def:torsion_group} and a small cofactor group of order $3$. We use the following notation for the large prime order group
 \begin{equation}
 \label{def:BLS6613}
@@ -2244,7 +2244,7 @@ Compute the following expressions: $-(26,34)$, $(26,9)\oplus(13,28)$, $(35,15)\o
 %To see how the small prime-order group of $BLS6\_6$ looks like we can apply the same approach but for the cofactor $13$ instead (EXERCISE). We get 
 %$$BLS6\_6[3]=\{\mathcal{O},(0,7),(0,36)\}$$
 %Now that we ha
-\subsubsection{Pairing groups}
+\subsubsection{Pairing Groups}
 \label{sec:bls66-pairing-groups}
 We know that $BLS6\_6$ is a pairing-friendly curve by design, since it has a small embedding degree $k=6$. It is therefore possible to compute Weil pairings efficiently. However, in order to do so, we have to decide the pairing groups $\G_1$ and $\G_2$ as defined in section \ref{sec:pairing_groups}. 
 
@@ -2326,7 +2326,7 @@ Again, having a logarithmic description of $\G_2[13]$ is helpful in pen-and-pape
 \end{align*}
 As this computation shows \ref{BLS6-G2-log} is really all we need to do computations in $\G_2[13]$ efficiently. The groups $\G_1[13]$ and $\G_2[13]$ are therefore suitable as pen-and-paper cryptographic pairing groups. 
 
-\subsubsection{The Weil pairing}
+\subsubsection{The Weil Pairing}
 In \ref{sec:bls66-pairing-groups} we computed two different groups, $\G_1[13]$ and $\G_2[13]$, which are subgroups of the full $13$-torsion group of the extended moon-math-curve $BLS6\_6(\F_{43^6})$. As explained in \ref{sec:weil-pairing}, this implies that there is a Weil pairing 
 \begin{equation}
 \label{BLS6-weil-pairing}
@@ -2361,7 +2361,7 @@ Consider the extended $BLS6\_6$ curve as defined in \ref{def:extended-bls6} and 
 $e(g1,g2)$ using definition \ref{eq:weil-pairing} and Miller's algorithm \ref{alg:millersalgo}.
 \end{exercise}
 \begin{comment}
-\subsection{Hashing to pairing groups}
+\subsection{Hashing to Pairing Groups}
 We give various constructions to hash into $\mathbb{G}_1$ and $\mathbb{G}_2$. 
 
 We start with hashing to the scalar field... \smelong{TO APPEAR}\sme{finish writing this up}

--- a/chapters/intro-moonmath.tex
+++ b/chapters/intro-moonmath.tex
@@ -12,13 +12,13 @@ However, the intricacies of zero-knowledge proofs are complicated and require an
 
 The 'MoonMath Manual to zk-SNARKs' aims to change this, designed specifically for individuals with limited prior exposure to cryptography. The manual aims to bridge knowledge gaps by providing a hands-on, practical approach to explaining abstract concepts using simple pen-and-paper calculations. As readers work through the manual, they will gain an understanding of the mathematics underlying zk-SNARKs, which will provide them with the necessary foundation for further exploration.
 
-\section{Target audience}
+\section{Target Audience}
 The primary focus of this book are software and smart contract developers who aim to acquire a thorough understanding of the workings of zk-SNARKs, in order to be able to develop high quality, high security code, or who want to close some knowledge gaps. The book is suitable for both novice and experienced readers, as concepts are gradually introduced in a structured and logical manner, ensuring that the information is easily comprehensible.
 
 While the book is accessible to a wide range of readers, it is expected that the reader has a basic knowledge of programming and an interest in logical thinking and strategic problem solving. An enthusiasm for the subject matter is also necessary, as the details of zero-knowledge proofs can be complex. 
 
 
-\section{About the book}
+\section{About the Book}
 How much mathematics do you need to understand and implement zero-knowledge proofs? Of course, the answer is contingent upon the desired level of comprehension and the security demands of the application. It is possible to implement zero-knowledge proofs without any understanding of the underlying mathematics; however, to read a seminal paper, to grasp the intricacies of a proof system, or to develop secure and high-quality zk-SNARKs, some mathematical knowledge is indispensable.
 
 Without a solid grounding in mathematics, someone who is interested in learning the concepts of zero-knowledge proofs, but who has never seen or dealt with, say, a prime field, or an elliptic curve, may quickly become overwhelmed. This is not so much due to the complexity of the mathematics needed, but rather because of the vast amount of technical jargon, unknown terms, and obscure symbols that quickly makes a text unreadable, even though the concepts themselves are not actually that complicated. As a result, the reader might either lose interest, or pick up some incoherent bits and pieces of knowledge that, in the worst case scenario, result in immature and non-secure implementations. 
@@ -32,7 +32,7 @@ It is important to emphasize that the mathematics presented in this book is info
 As a novice, it is suggested that one first computes a simple toy zk-SNARK using pen and paper, before venturing into the development of high-security real-world zk-SNARKs. However, to derive these toy examples, some mathematical preparation is necessary. This book therefore aims to guide the inexperienced reader towards the essential mathematical concepts, providing exercises that are intended to be worked through independently. Each section includes a list of progressively challenging exercises to aid in memorization and application of the concepts.
 
 
-\section{Reading this Book}
+\section{Reading This Book}
 The MoonMath Manual is intended to provide a comprehensive introduction to topics relevant to beginners in mathematics and cryptography. As such, there are multiple ways to read the book. The most straightforward approach is to follow the chapters in a linear order. This method is recommended for readers who have limited prior knowledge of mathematics and cryptography. The book begins with fundamental concepts such as natural numbers, prime numbers, and operations on these sets in various arithmetics. Subsequently, the book progresses to cover algebraic structures, including groups, rings, prime fields, and elliptic curves.
 
 Throughout the book, examples are introduced and gradually expanded upon with the incorporation of new knowledge from subsequent chapters. This incremental approach allows for the development of simple, yet full-fledged cryptographic systems that can be computed by hand, in order to provide a detailed illustration of each step.

--- a/chapters/statements-moonmath.tex
+++ b/chapters/statements-moonmath.tex
@@ -295,7 +295,7 @@ Although decision functions are expressible in various ways, many contemporary p
 
 In this section, we will have a closer look at a particular type of quadratic equations called \term{Rank-1 (quadratic) Constraint Systems} (R1CS), which are a common standard in zero-knowledge proof systems (cf. appendix E of \cite{sasson-2013}). We will start with a general introduction to those constraint systems and then look at their relation to formal languages. Then we will look into a common way to compute solutions to those systems. 
 
-\subsubsection{R1CS representation} To understand what \term{Rank-1 (quadratic) Constraint Systems}) (R1CS) are in detail, let $\F$ be a field, $n$, $m$ and $k\in\N$ three numbers and $a_j^i$, $b_j^i$ and $c_j^i\in\F$ constants from $\F$ for every index $0\leq j \leq n+m$ and $1\leq i \leq k$. Then a \concept{rank-1 constraint system} is defined as the following set of $k$ many equations:\tbdsm{font size too small} 
+\subsubsection{R1CS Representation} To understand what \term{Rank-1 (quadratic) Constraint Systems}) (R1CS) are in detail, let $\F$ be a field, $n$, $m$ and $k\in\N$ three numbers and $a_j^i$, $b_j^i$ and $c_j^i\in\F$ constants from $\F$ for every index $0\leq j \leq n+m$ and $1\leq i \leq k$. Then a \concept{rank-1 constraint system} is defined as the following set of $k$ many equations:\tbdsm{font size too small} 
 
 \begin{definition}[\deftitle{Rank-1 (quadratic) Constraint System}]\label{R1CS}
 \begin{equation}\label{eq:R1CS}
@@ -493,7 +493,7 @@ Methods which compute R1CS solutions are sometimes called \term{witness generato
 It can be shown that every space- and time-bounded computation is expressible as an algebraic circuit. Transforming high-level computer programs into those circuits is a process often called \term{flattening}. We will look at those transformations in \chaptname{} \ref{chap:circuit-compilers}.
 
 In this section we will introduce our model for algebraic circuits and look at the concept of circuit execution and valid assignments. After that, we will show how to derive \concept{rank-1 constraint systems} from circuits and how circuits are useful to compute solutions to associated R1CS efficiently.
-\subsubsection{Algebraic circuit representation} To see what algebraic circuits are, let $\F$ be a field. An algebraic circuit is then a directed acyclic multi-graph that computes a polynomial function over $\F$. Nodes with only outgoing edges (source nodes) represent the variables and constants of the function and nodes with only incoming edges (sink nodes) represent the outcome of the function. All other nodes have exactly two incoming edges and represent the field operations \term{addition} as well as \term{multiplication}. Graph edges are directed and represent the flow of the computation along the nodes.
+\subsubsection{Algebraic Circuit Representation} To see what algebraic circuits are, let $\F$ be a field. An algebraic circuit is then a directed acyclic multi-graph that computes a polynomial function over $\F$. Nodes with only outgoing edges (source nodes) represent the variables and constants of the function and nodes with only incoming edges (sink nodes) represent the outcome of the function. All other nodes have exactly two incoming edges and represent the field operations \term{addition} as well as \term{multiplication}. Graph edges are directed and represent the flow of the computation along the nodes.
 
 To be more precise, in this book, we call a directed acyclic multi-graph $C(\F)$  an \term{algebraic circuit} over $\F$ if the following conditions hold:
 
@@ -1257,7 +1257,7 @@ One reason why those systems are useful in the context of succinct zero-knowledg
 
 As we will see, proving statements for languages that have decision functions defined by Quadratic Arithmetic Programs can be achieved by providing certain polynomials, and those proofs can be verified by checking a particular divisibility property of those polynomials.
  
-\subsubsection{QAP representation} To understand what Quadratic Arithmetic Programs are in detail, let $\F$ be a field and $R$ a \concept{rank-1 constraint system} over $\F$ such that the number of non-zero elements in $\F$ is strictly greater than the number $k$ of constraints in $R$. Moreover, let $a_j^i$, $b_j^i$ and $c_j^i\in\F$ for every index $0\leq j \leq n+m$ and $1\leq i \leq k$, be the defining constants of the R1CS and $m_1$, $\ldots$, $m_k$ be arbitrary, invertible and distinct elements from $\F$.
+\subsubsection{QAP Representation} To understand what Quadratic Arithmetic Programs are in detail, let $\F$ be a field and $R$ a \concept{rank-1 constraint system} over $\F$ such that the number of non-zero elements in $\F$ is strictly greater than the number $k$ of constraints in $R$. Moreover, let $a_j^i$, $b_j^i$ and $c_j^i\in\F$ for every index $0\leq j \leq n+m$ and $1\leq i \leq k$, be the defining constants of the R1CS and $m_1$, $\ldots$, $m_k$ be arbitrary, invertible and distinct elements from $\F$.
   
 Then a \term{Quadratic Arithmetic Program} associated to the R1CS $R$ is the following set of polynomials over $\F$:
 \begin{equation}


### PR DESCRIPTION
- Use title case for section, subsection, subsubsection titles
- Change subgroups and subrings definition such that groups/rings are subgroups/subrings of themselves -- since there are at least 3 other places in the book which mention that group is subgroup of itself
- Reword cyclic group definition
- Fix small formatting problems in formulas
- Various fixes to section on hashing functions