### PR TITLE
docs: correct number of points at infinity in an example

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -1407,7 +1407,7 @@ These lines define the $13$ points in the projective plane $\F_3\mathbb{P}$:
 \begin{multline*}
 \F_3\mathbb{P} = \{ [0:0:1], [0:1:0], [0:1:1], [0:1:2], [1:0:0], [1:0:1], \\ [1:0:2], [1:1:0], [1:1:1], [1:1:2], [1:2:0], [1:2:1], [1:2:2]\}
 \end{multline*}
-This projective plane contains $9$ affine points, three points at infinity and one line at infinity.
+This projective plane contains $9$ affine points, four points at infinity and one line at infinity.
 
 To understand the ambiguity in projective coordinates a bit better, let us consider the point $[1:2:2]$. As this point in the projective plane is a line in $\F_3^3\backslash\{(0,0,0)\}$, it has the projective coordinates $(1,2,2)$ as well as $(2,1,1)$, since the former coordinate gives the latter when multiplied in $\F_3$ by the factor $2$. In addition, note that, for the same reasons, the points $[1:2:2]$ and $[2:1:1]$ are the same, since their underlying sets are equal.
 \end{example}


### PR DESCRIPTION
Based on provided definition, aren't there four points at infinity?