### PR TITLE
Fixed label and reference to TJJ13-twisted-edwards

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -945,7 +945,7 @@ On the other hand, a Montgomery curve $By^{2}=x^{3}+Ax^{2}+x$ such that $B\neq 0
 (\frac{A+2}{B})x^2+y^2= 1+(\frac{A-2}{B})x^2y^2
 \end{equation}
 
-\begin{example}Consider the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13} again. We know from \examplename{} \ref{TJJ13-montgomery} that it is a Montgomery curve, and, since Montgomery curves are equivalent to \concept{twisted Edwards} curves, we want to write this curve in \concept{twisted Edwards} form. We use equation \eqref{eq:montgomery-to-twisted-edwards}, and compute the parameters $a$ and $d$ as follows:
+\begin{example}\label{ex:TJJ13-twisted-edwards}Consider the \curvename{Tiny-jubjub} curve from \examplename{} \ref{TJJ13} again. We know from \examplename{} \ref{TJJ13-montgomery} that it is a Montgomery curve, and, since Montgomery curves are equivalent to \concept{twisted Edwards} curves, we want to write this curve in \concept{twisted Edwards} form. We use equation \eqref{eq:montgomery-to-twisted-edwards}, and compute the parameters $a$ and $d$ as follows:
 \begin{align*}
 a & = \frac{A+2}{B} & \text{\# insert A=6 and B=7}\\
   & = \frac{8}{7} = 3 & \text{\# } 7^{-1}= 2 \\
@@ -969,7 +969,7 @@ Since our goal is to use this curve later in implementations of pen-and-paper SN
 \end{align*}
 
 This proves that \curvename{Tiny-jubjub} is SNARK-friendly. We can write the \curvename{Tiny-jubjub} curve in its affine \concept{twisted Edwards} representation as follows:
-\begin{equation}\label{TJJ13-twisted-edwards}
+\begin{equation}\label{eq:TJJ13-twisted-edwards}
 \mathit{TJJ\_13} = \{(x,y)\in \F_{13}\times \F_{13}\;|\; 3\cdot x^{2} + y^2 =1+ 8\cdot x^{2}\cdot y^2 \}
 \end{equation}
 

--- a/chapters/statements-moonmath.tex
+++ b/chapters/statements-moonmath.tex
@@ -117,7 +117,7 @@ Having defined the language $L_{3.fac}$, it then makes sense to claim the statem
 
 Proving the correctness of this statement constructively means to actually find some concrete field elements that satisfy the decision function $R_{3.fac}$, like $x_1= 2$, $x_2 =12$, $x_3=4$ and $x_4 = 5$. The string $<2,12,4,5>$ is therefore a constructive proof for the statement that $L_{3.fac}$ contains words, and the computation $R_{3.fac}(<2,12,4,5>)=true$ is a verification of that proof. In contrast, the string $<2, 12, 4, 7>$ is not a proof of the statement, since the check $R_{3.fac}(<2,12,4,7>)=false$ does not verify the proof.
 \end{example}
-\begin{example}[\curvename{Tiny-jubjub} Membership]\label{ex:tiny-jubjub} In one of our main examples, we derive a SNARK that proves a pair $(x,y)$ of field elements from $\F_{13}$ to be a point on the tiny-{jubjub} curve in its twisted Edwards form as derived in \examplename{} \ref{TJJ13-twisted-edwards}.
+\begin{example}[\curvename{Tiny-jubjub} Membership]\label{ex:tiny-jubjub} In one of our main examples, we derive a SNARK that proves a pair $(x,y)$ of field elements from $\F_{13}$ to be a point on the tiny-{jubjub} curve in its twisted Edwards form as derived in \examplename{} \ref{ex:TJJ13-twisted-edwards}, equation \ref{eq:TJJ13-twisted-edwards}.
 
 In the first step, we define a language such that points on the \curvename{Tiny-jubjub} curve are in 1:1 correspondence with words in that language.
 


### PR DESCRIPTION
Chapter 6 example Tiny-jubjub Membership referenced equation instead of example, which had no label. Therefore added in chapter 5 label for ex: AND eq:TJJ13-twisted-edward