### PR TITLE
fix a typo in commutative rings definition

### DIFF
--- a/chapters/algebra-moonmath.tex
+++ b/chapters/algebra-moonmath.tex
@@ -635,9 +635,9 @@ A \term{commutative ring with unit} $ (R, +, \cdot, 1) $ is a set $R$ with two m
 \item $ (R, +) $ is a commutative group where the neutral element is denoted  with $ 0 $.
 \item \hilight{Commutativity of multiplication}: $r_1\cdot r_2 = r_2\cdot r_1$ for all $r_1, r_2\in R$.
 \item \hilight{Multiplicative neutral unit }: $1\cdot g=g$ for all $g\in R$.
-\item \hilight{Associativity}: For every $g_1,g_2,g_3\in\R$, the equation
+\item \hilight{Associativity}: For every $g_1,g_2,g_3\in R$, the equation
 $g_1\cdot(g_2\cdot g_3) = (g_1\cdot g_2)\cdot g_3$ holds.
-\item \hilight{Distributivity}: For all $ g_1, g_2, g_3 \in\R $, the distributive law
+\item \hilight{Distributivity}: For all $ g_1, g_2, g_3 \in R $, the distributive law
 $ g_1 \cdot \left (g_2 + g_3 \right) = g_1 \cdot g_2 + g_1 \cdot g_3$ holds.
 \end{itemize}
 If $(R,+,\cdot,1)$ is a commutative ring with unit, and $R'\subseteq R$ is a subset of $R$ such that the restriction of addition and multiplication to $R'$ define a commutative ring with addition $+: R'\times R' \to R'$, multiplication $\cdot: R'\times R' \to R'$ and unit $1$ on $R'$, then $(R',+,\cdot,1)$ is called a \term{subring} of $(R,+,\cdot,1)$.


### PR DESCRIPTION
In the definition of Commutative Rings the Ring is mistakenly noted as $\mathbb{R}$ instead of $R$ in a couple of places.

<img width="806" height="319" alt="Screenshot 2026-03-15 at 14 41 49" src="https://github.com/user-attachments/assets/04b1e876-1b83-4774-bf32-cb08afcb6527" />
