### PR TITLE
Fix reference to Tiny-jubjub curve equation

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -1005,7 +1005,7 @@ To see what the \concept{twisted Edwards} group law looks like, let $(x_1, y_1)$
 In order to see what the neutral element of the group law is, first observe that the point $(0,1)$ is a solution to the \concept{twisted Edwards} equation $a\cdot x^{2} + y^2 =1+ d\cdot x^{2}\cdot y^2$ for any parameters $a$ an $d$, and hence $(0,1)$ is a point on any \concept{twisted Edwards} curve. It can be shown that $(0,1)$ serves as the neutral element, and that the inverse of a point $(x_1, y_1)$ is given by the point $(-x_1, y_1)$.
 \begin{example}
 \label{example:TETJJ13}
- Let's look at the \curvename{Tiny-jubjub} curve in Edwards form from \eqref{TJJ13-twisted-edwards} again. As we have seen, this curve is given by as follows:
+ Let's look at the \curvename{Tiny-jubjub} curve in Edwards form from \eqref{eq:TJJ13-twisted-edwards} again. As we have seen, this curve is given by as follows:
 \begin{multline}
 \mathit{TE\_TJJ\_13} = \{(0, 1),(0, 12),(1, 2),(1, 11),(2, 6),(2, 7),(3, 0),(5, 5),(5, 8),(6, 4),\\
 (6, 9),(7, 4),(7, 9),(8, 5),(8, 8),(10, 0),(11, 6),(11, 7),(12, 2),(12, 11)\}


### PR DESCRIPTION
<img width="830" height="150" alt="Screenshot 2026-03-31 at 19 26 22" src="https://github.com/user-attachments/assets/5fb99bb3-385b-46f7-a9b4-6aa9477f21ff" />
Currently the link is broken.