### PR TITLE
Fix variable name in BLS6 curve design explanation

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -2066,7 +2066,7 @@ Here $x\in\NN$ is a parameter that the designer has to choose in such a way that
 
 In order to design the smallest BLS6 curve, we therefore have to find a parameter $x$ such that $t(x)$ and $p(x)$ are the smallest natural numbers that satisfy $p(x)>3$.\footnote{The smallest BLS curve will also be the most insecure BLS curve. However, since our goal with this curve is ease of pen-and-paper computation rather than security, it fits the purposes of this book.}
 
-We therefore initiate the design process of our $BLS6$ curve by inserting small values for $x$ into the defining polynomials $t$ and $q$. We get the following results:
+We therefore initiate the design process of our $BLS6$ curve by inserting small values for $x$ into the defining polynomials $t$ and $p$. We get the following results:
 $$
 \begin{array}{lcr}
 x=1 & (t(x),p(x)) & (2,1)\\


### PR DESCRIPTION
Corrected the variable name from $q$ to $p$ in the BLS6 curve design process description. The polynomials are $p$ and $t$, $q$ is a typo.