### PR TITLE
Fix typo in elliptic curve example

### DIFF
--- a/chapters/elliptic-curves-moonmath.tex
+++ b/chapters/elliptic-curves-moonmath.tex
@@ -2319,7 +2319,7 @@ Repeatedly adding a generator to itself generates small groups in logarithmic or
 
 Again, having a logarithmic description of $\G_2[13]$ is helpful in pen-and-paper computations, as it reduces complicated computation in the extended curve to modular $13$ arithmetic, as in the following example:
 \begin{align*}
-(17v^2,28v^3)\oplus (10v^2,15v^2)  & = [6](7v^2,16v^3)\oplus [11](7v^2,16v^3)\\
+(17v^2,28v^3)\oplus (10v^2,15v^3)  & = [6](7v^2,16v^3)\oplus [11](7v^2,16v^3)\\
                       & = [6+11](7v^2,16v^3)\\
                       & = [4](7v^2,16v^3)\\
                       & = (37v^2,27v^3)\\


### PR DESCRIPTION
The element should be $(10 v^2, 15 v^3)$